### PR TITLE
Align submit page and Supabase flow with category-only reporting requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Set the config object in a small script before `index.html` app logic in product
   window.NAMEHIM_CONFIG = {
     SUPABASE_URL: 'https://YOUR_PROJECT.supabase.co',
     SUPABASE_ANON_KEY: 'YOUR_ANON_KEY',
-    TURNSTILE_SITE_KEY: 'YOUR_TURNSTILE_SITE_KEY'
+    TURNSTILE_SITE_KEY: 'YOUR_TURNSTILE_SITE_KEY',
+    TURNSTILE_VERIFY_ENDPOINT: 'https://YOUR_WORKER_OR_FUNCTION/verify-turnstile'
   };
 </script>
 ```
@@ -20,8 +21,9 @@ Set the config object in a small script before `index.html` app logic in product
 
 1. Run the SQL in `supabase.sql`.
 2. Enable Realtime for `public.reports` table.
-3. Enable Anonymous sign-ins in Supabase Auth settings.
-4. (Recommended for production) Verify Turnstile tokens server-side via a Cloudflare Worker / Supabase Edge Function before insert.
+3. Enable Anonymous sign-ins in Supabase Auth settings (so each reporter gets a UUID-backed user).
+4. Verify Turnstile tokens server-side via a Cloudflare Worker / Supabase Edge Function **before** inserting to `reports`.
+5. Insert only `name`, `city`, `state`, `categories`, and `submitter_uuid`.
 
 ## Run locally
 

--- a/index.html
+++ b/index.html
@@ -71,8 +71,8 @@
             <input id="city" required type="text" class="w-full bg-muted border border-slate-600 rounded px-3 py-2" />
           </div>
           <div>
-            <label class="block mb-1">State * (2-letter)</label>
-            <input id="state" required maxlength="2" type="text" class="w-full uppercase bg-muted border border-slate-600 rounded px-3 py-2" />
+            <label class="block mb-1">State * (2-letter uppercase)</label>
+            <input id="state" required maxlength="2" pattern="[A-Z]{2}" placeholder="CA" type="text" class="w-full uppercase bg-muted border border-slate-600 rounded px-3 py-2" />
           </div>
         </div>
 
@@ -80,11 +80,6 @@
           <legend class="mb-2">Categories *</legend>
           <div class="grid grid-cols-1 sm:grid-cols-2 gap-2" id="category-checkboxes"></div>
         </fieldset>
-
-        <div>
-          <label class="block mb-1">Description (optional, max 500 chars)</label>
-          <textarea id="description" maxlength="500" rows="4" class="w-full bg-muted border border-slate-600 rounded px-3 py-2"></textarea>
-        </div>
 
         <div>
           <div class="cf-turnstile" data-theme="dark" data-size="flexible" data-appearance="interaction-only"></div>
@@ -128,7 +123,8 @@
     const config = {
       SUPABASE_URL: window.NAMEHIM_CONFIG?.SUPABASE_URL || 'YOUR_SUPABASE_URL',
       SUPABASE_ANON_KEY: window.NAMEHIM_CONFIG?.SUPABASE_ANON_KEY || 'YOUR_SUPABASE_ANON_KEY',
-      TURNSTILE_SITE_KEY: window.NAMEHIM_CONFIG?.TURNSTILE_SITE_KEY || 'YOUR_TURNSTILE_SITE_KEY'
+      TURNSTILE_SITE_KEY: window.NAMEHIM_CONFIG?.TURNSTILE_SITE_KEY || 'YOUR_TURNSTILE_SITE_KEY',
+      TURNSTILE_VERIFY_ENDPOINT: window.NAMEHIM_CONFIG?.TURNSTILE_VERIFY_ENDPOINT || ''
     };
 
     const supabase = window.supabase.createClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY);
@@ -148,6 +144,44 @@
         localStorage.setItem('submitter_id', id);
       }
       return id;
+    }
+
+    async function ensureAnonymousSession() {
+      const { data: { user } } = await supabase.auth.getUser();
+      if (user?.id) {
+        localStorage.setItem('submitter_id', user.id);
+        return user.id;
+      }
+
+      const { data, error } = await supabase.auth.signInAnonymously();
+      if (error) {
+        throw new Error(`Anonymous sign-in failed: ${error.message}`);
+      }
+
+      const submitterId = data.user?.id || crypto.randomUUID();
+      localStorage.setItem('submitter_id', submitterId);
+      return submitterId;
+    }
+
+    async function verifyTurnstileToken(token) {
+      if (!config.TURNSTILE_VERIFY_ENDPOINT) {
+        throw new Error('Turnstile verification endpoint is not configured.');
+      }
+
+      const response = await fetch(config.TURNSTILE_VERIFY_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
+      });
+
+      if (!response.ok) {
+        throw new Error('Turnstile verification request failed.');
+      }
+
+      const result = await response.json();
+      if (!result?.success) {
+        throw new Error('Turnstile verification failed. Please try again.');
+      }
     }
 
     function setupCategoriesUI() {
@@ -264,7 +298,6 @@
       const name = document.getElementById('name').value.trim();
       const city = document.getElementById('city').value.trim();
       const state = document.getElementById('state').value.trim().toUpperCase();
-      const description = document.getElementById('description').value.trim();
       const categories = Array.from(document.querySelectorAll('input[name="categories"]:checked')).map(el => el.value);
 
       if (!categories.length) {
@@ -273,20 +306,32 @@
         return;
       }
 
+      if (!/^[A-Z]{2}$/.test(state)) {
+        submitMessage.textContent = 'State must be a 2-letter uppercase code.';
+        submitMessage.className = 'mt-4 text-sm text-red-400';
+        return;
+      }
+
       submitBtn.disabled = true;
 
-      const payload = {
-        name,
-        city,
-        state,
-        categories,
-        description: description || null,
-        submitter_uuid: localStorage.getItem('submitter_id')
-      };
+      try {
+        await verifyTurnstileToken(token);
+        const submitterUuid = await ensureAnonymousSession();
 
-      const { error } = await supabase.from('reports').insert(payload);
+        const payload = {
+          name,
+          city,
+          state,
+          categories,
+          submitter_uuid: submitterUuid
+        };
 
-      if (error) {
+        const { error } = await supabase.from('reports').insert(payload);
+
+        if (error) {
+          throw new Error(error.message);
+        }
+      } catch (error) {
         submitMessage.textContent = `Submission failed: ${error.message}`;
         submitMessage.className = 'mt-4 text-sm text-red-400';
         submitBtn.disabled = false;
@@ -335,6 +380,7 @@
 
     async function bootstrap() {
       initializeSubmitterId();
+      await ensureAnonymousSession();
       setupCategoriesUI();
       updateRateLimitUI();
       setupReportButtons();

--- a/supabase.sql
+++ b/supabase.sql
@@ -6,7 +6,6 @@ create table if not exists public.reports (
   city text not null,
   state text not null,
   categories text[] not null,
-  description text,
   created_at timestamptz not null default now(),
   submitter_uuid text not null
 );
@@ -19,7 +18,7 @@ on public.reports
 for select
 using (true);
 
--- Public insert access (Turnstile should be verified in an edge function/worker in production)
+-- Public insert access (after Turnstile validation in your worker/edge function)
 create policy if not exists "Public can insert reports"
 on public.reports
 for insert


### PR DESCRIPTION
### Motivation
- Limit submissions to the required fields (Full Name, City, State, category checkboxes) and remove freeform descriptions from the client and DB schema.
- Enforce a 2-letter uppercase `state` input and client-side rate limiting while ensuring submissions are tied to a persistent anonymous UUID.
- Require server-side Turnstile verification before inserting into Supabase to reduce automated abuse.

### Description
- Removed the `description` textarea and related handling from `index.html` and removed the `description` column from `supabase.sql` so reports only store `name`, `city`, `state`, `categories`, `created_at`, and `submitter_uuid`.
- Added a `pattern`/placeholder and client validation for 2-letter uppercase `state` values and an explicit check in `submitReport` using `/^[A-Z]{2}$/`.
- Implemented `ensureAnonymousSession()` to perform `supabase.auth.signInAnonymously()` and persist the reporter UUID to `localStorage` for use as `submitter_uuid` on insert.
- Added `verifyTurnstileToken(token)` and a new `TURNSTILE_VERIFY_ENDPOINT` config entry so the client calls a server-side verification endpoint before attempting an insert, and updated the insert payload to send only `name`, `city`, `state`, `categories`, and `submitter_uuid`.
- Updated `README.md` to document the `TURNSTILE_VERIFY_ENDPOINT`, anonymous auth expectation, and the requirement to insert only the specified fields.

### Testing
- Ran targeted static checks using `rg -n "Description|submitter_uuid|TURNSTILE_VERIFY_ENDPOINT|signInAnonymously|categories"` to verify the new symbols appear in `index.html`, `supabase.sql`, and `README.md`, and the command completed successfully.
- Inspected the modified files with `nl`/`sed` to confirm the `description` removal, the new `TURNSTILE_VERIFY_ENDPOINT` config, the `ensureAnonymousSession` and `verifyTurnstileToken` functions, and the updated `supabase.sql` schema, and these inspections showed the expected changes.
- No automated unit tests exist for the static frontend in this repo, so remaining validation assumes integration testing against a configured `TURNSTILE_VERIFY_ENDPOINT` and a Supabase project with Anonymous sign-in enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9c455608832f8f5552fdbdd0ac9c)