### PR TITLE
Fix submit tab routing by normalizing hashes

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,9 @@
     const CATEGORIES = Object.keys(CATEGORY_COLORS);
     const routes = {
       '#/browse': 'page-browse',
-      '#/submit': 'page-submit'
+      '#browse': 'page-browse',
+      '#/submit': 'page-submit',
+      '#submit': 'page-submit'
     };
 
     const config = {
@@ -364,13 +366,22 @@
       });
     }
 
+    function normalizeRouteHash(rawHash) {
+      if (!rawHash || rawHash === '#') return '#/browse';
+      const cleaned = rawHash.toLowerCase().replace(/^#!?\/?/, '');
+      if (cleaned === 'submit') return '#/submit';
+      return '#/browse';
+    }
+
     function renderRoute() {
-      const hash = routes[location.hash] ? location.hash : '#/browse';
+      const hash = normalizeRouteHash(location.hash);
       if (location.hash !== hash) {
         location.hash = hash;
       }
-      Object.entries(routes).forEach(([route, id]) => {
-        document.getElementById(id).classList.toggle('hidden', route !== hash);
+
+      const targetSectionId = routes[hash];
+      ['page-browse', 'page-submit'].forEach((id) => {
+        document.getElementById(id).classList.toggle('hidden', id !== targetSectionId);
       });
     }
 


### PR DESCRIPTION
### Motivation
- The Submit page sometimes failed to appear because the router only matched a single hash format and silently fell back to the browse view. 
- The intent is to make hash-based navigation robust against common variants like `#/submit`, `#submit`, or empty/`#` hashes so the header links reliably open the expected section.

### Description
- Add a `normalizeRouteHash` helper that canonicalizes incoming `location.hash` values (handles empty/hash-only, `#submit`, `#/submit`, and ignores leading `#!`), and returns the canonical `#/submit` or `#/browse` values. 
- Extend the `routes` mapping to include both `#/submit`/`#submit` and `#/browse`/`#browse` variants. 
- Replace the previous generic route toggle with explicit logic that uses the normalized hash and directly toggles visibility of `page-browse` and `page-submit` so route rendering is deterministic.

### Testing
- Ran a repository diff-check (`git diff --check`) and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab0b83914832fa7af44d57a4fd576)