### PR TITLE
Make header title link to homepage

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,7 +27,7 @@
 
   <header class="border-b border-slate-700 bg-panel/90 backdrop-blur sticky top-0 z-20">
     <div class="max-w-6xl mx-auto px-4 py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
-      <h1 class="text-2xl font-bold tracking-wide">NameHim</h1>
+      <h1 class="text-2xl font-bold tracking-wide"><a href="index.html#/browse" class="hover:underline underline-offset-4">NameHim</a></h1>
       <nav class="flex flex-wrap gap-2 text-sm">
         <a href="index.html#/browse" class="px-3 py-2 rounded bg-muted hover:bg-slate-600 transition">Home</a>
         <a href="index.html#/submit" class="px-3 py-2 rounded bg-muted hover:bg-slate-600 transition">Submit</a>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,8 @@
     .page.active { display: block; }
 
     h1 { margin: 0; font-size: 1.7rem; }
+    .site-title-link { color: inherit; text-decoration: none; }
+    .site-title-link:hover { text-decoration: underline; text-underline-offset: 0.18em; }
     h2 { margin-top: 0; margin-bottom: 1rem; font-size: 1.4rem; }
 
     .controls {
@@ -279,7 +281,7 @@
 
   <header>
     <div class="container header-inner">
-      <h1>NameHim</h1>
+      <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Provide a consistent, discoverable way for users to return to the homepage by making the site brand/title clickable from pages with the header.

### Description
- Wrap the `NameHim` header text in an `<a>` pointing to `index.html#/browse` in both `index.html` and `about.html` and add a `.site-title-link` rule in `index.html` to preserve visual styling and add a hover underline.

### Testing
- Verified the HTML changes with `git diff -- index.html about.html` and inspected the modified lines with `nl -ba index.html | sed -n '82,100p;274,290p' && nl -ba about.html | sed -n '24,38p'`, both commands succeeded; there is no automated test suite in this repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac60f9b5c832fad416607709fdc87)