### PR TITLE
Fix incorrect GitHub hrefs on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -59,7 +59,7 @@
         <h3 class="text-lg font-semibold mb-2">Open source &amp; transparency</h3>
         <p>
           This entire project is open source. You can read every line of code, suggest improvements, or report issues at our GitHub repository:
-          <a class="underline underline-offset-2 text-blue-300 hover:text-blue-200" href="https://github.com/YOUR-USERNAME/namehim-app">https://github.com/namehim/namehim</a>
+          <a class="underline underline-offset-2 text-blue-300 hover:text-blue-200" href="https://github.com/namehim/namehim">https://github.com/namehim/namehim</a>
         </p>
       </section>
 
@@ -79,7 +79,7 @@
     <div class="max-w-6xl mx-auto px-4 py-4 text-sm text-slate-300 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
       <div class="flex gap-4">
         <a href="about.html" class="hover:text-white underline underline-offset-2">About</a>
-        <a href="https://github.com/YOUR-USERNAME/namehim-app" class="hover:text-white underline underline-offset-2">GitHub</a>
+        <a href="https://github.com/namehim/namehim" class="hover:text-white underline underline-offset-2">GitHub</a>
       </div>
       <p>Open source – fork and improve</p>
     </div>


### PR DESCRIPTION
### Motivation
- Replace placeholder GitHub links on the About page with the actual repository URL so visitors are directed to `https://github.com/namehim/namehim` instead of the `YOUR-USERNAME` placeholder.

### Description
- Updated `about.html` to replace `https://github.com/YOUR-USERNAME/namehim-app` with `https://github.com/namehim/namehim` for both the inline repo link and the footer GitHub link.

### Testing
- Ran `rg -n "YOUR-USERNAME|namehim-app" about.html; rg -n "github.com/namehim/namehim" about.html` and verified there are no remaining placeholder URLs and both links point to `https://github.com/namehim/namehim`, and committed the change with `git add about.html && git commit -m "Fix About page GitHub links"` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaca17f008832fb0866d2479259088)