### PR TITLE
Show USA abbreviation in browse report locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -721,8 +721,16 @@
       localStorage.setItem(RATE_LIMIT_STORAGE_KEY, JSON.stringify(timestamps));
     }
 
+    function formatCountryForBrowse(country) {
+      const normalizedCountry = String(country || '').trim().toLowerCase();
+      if (normalizedCountry === 'united states of america') {
+        return 'USA';
+      }
+      return country;
+    }
+
     function formatLocation(city, state, country) {
-      const parts = [city, state, country]
+      const parts = [city, state, formatCountryForBrowse(country)]
         .map((part) => (part || '').trim())
         .filter((part) => part.length > 0)
         .map((part) => escapeHTML(part));


### PR DESCRIPTION
### Motivation
- On the Browse reports page the country field displays `United States of America` verbatim; the UI should show the shorter `USA` abbreviation for that country in the report list.

### Description
- Added a small formatter `formatCountryForBrowse(country)` that maps `United States of America` to `USA` and updated `formatLocation` to call `formatCountryForBrowse` before rendering the location in `index.html`.

### Testing
- No automated tests are configured in this repository; I verified the change by inspecting the updated `index.html` (`formatCountryForBrowse` and the modified `formatLocation`) and committing the change with `git commit` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacd2079e0832fbac07af97bd474cd)