### PR TITLE
Add 'pedo' category and pill style

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@
     .stalking { background: #facc15; color: #111827; }
     .sexual-assault { background: #a855f7; color: #fff; }
     .rape { background: #dc2626; color: #fff; }
+    .pedo { background: #14b8a6; color: #06202a; }
 
     .message {
       margin-top: 0.9rem;
@@ -594,7 +595,8 @@
       'physical abuse',
       'stalking',
       'sexual assault',
-      'rape'
+      'rape',
+      'pedo'
     ];
 
     const SUPABASE_URL = 'https://cmmggaprguusffiphegy.supabase.co';


### PR DESCRIPTION
### Motivation
- Add a new category so submissions can include the additional category and badges render with a matching distinct color in browse results.

### Description
- Appended `'pedo'` to the `CATEGORIES` array in `index.html` and added a `.pedo` CSS rule for the category pill color so it matches the existing badge pattern.

### Testing
- Ran `git diff --check` to validate there are no formatting issues and reviewed the updated `index.html`; no automated unit tests were required for this static HTML/CSS/JS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae2089510832f9a0e79465be887e9)