### PR TITLE
Style submit-form categories with color-coded labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,13 @@
       font-size: 0.9rem;
     }
 
+    .check.emotional-abuse { background: rgba(100, 116, 139, 0.2); border-color: #64748b; }
+    .check.physical-abuse { background: rgba(251, 146, 60, 0.2); border-color: #fb923c; }
+    .check.stalking { background: rgba(250, 204, 21, 0.2); border-color: #facc15; }
+    .check.sexual-assault { background: rgba(168, 85, 247, 0.2); border-color: #a855f7; }
+    .check.rape { background: rgba(220, 38, 38, 0.2); border-color: #dc2626; }
+    .check.pedo { background: rgba(20, 184, 166, 0.2); border-color: #14b8a6; }
+
     .warning { color: #f59e0b; font-size: 0.85rem; margin-top: 0.5rem; }
     .hidden { display: none !important; }
 
@@ -660,7 +667,7 @@
       categoryContainer.innerHTML = '';
       CATEGORIES.forEach((category) => {
         const label = document.createElement('label');
-        label.className = 'check';
+        label.className = 'check ' + getCategoryClass(category);
         label.innerHTML = '<input type="checkbox" name="categories" value="' + escapeHTML(category) + '"> <span>' + escapeHTML(toTitleCase(category)) + '</span>';
         categoryContainer.appendChild(label);
       });


### PR DESCRIPTION
### Motivation
- Harmonize the submit form checkbox appearance with the category pill palette so each category (including `sexual assault`) has a distinct, recognizable color in the submit UI.

### Description
- Added per-category checkbox label styles (`.check.<category>`) including `.check.sexual-assault` with a purple background tint and matching border color to mirror the report pills.
- Updated `renderCategories` so each checkbox label receives a category-specific class via `label.className = 'check ' + getCategoryClass(category)`.

### Testing
- No automated unit tests exist for this static HTML/CSS/JS change. 
- Verified the patch by inspecting the diff with `git diff -- index.html` and confirming the inserted CSS and the `renderCategories` modification using `nl -ba index.html | sed -n '248,276p'; nl -ba index.html | sed -n '656,674p'`, and both inspections succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eae9047260832fbd3eb7407acacb09)