### PR TITLE
Add moderated dataset link to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -61,6 +61,11 @@
           This entire project is open source. You can read every line of code, suggest improvements, or report issues at our GitHub repository:
           <a class="underline underline-offset-2 text-blue-300 hover:text-blue-200" href="https://github.com/namehim/namehim">https://github.com/namehim/namehim</a>
         </p>
+        <p class="mt-3">
+          If you want to fork this project or run your own version, you can download the live, moderated dataset at:
+          <a class="underline underline-offset-2 text-blue-300 hover:text-blue-200" href="https://api.namehim.app/filtered-reports">https://api.namehim.app/filtered-reports</a>.
+          The data is updated every 30 seconds and excludes any entries removed by moderation (trolls, fakes, or successful appeals).
+        </p>
       </section>
 
       <section>


### PR DESCRIPTION
### Motivation
- Provide a discoverable, live moderated dataset endpoint so people who fork or run the project can download the moderated reports feed.

### Description
- Added a new paragraph at the end of the `Open source & transparency` section in `about.html` linking to `https://api.namehim.app/filtered-reports` and noting the feed updates every 30 seconds and excludes entries removed by moderation.

### Testing
- No automated tests were run for this content-only HTML change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaf29ae2f8832fade1f7e48293c6fc)