### PR TITLE
Reorder location fields and add dynamic US state dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,15 +378,9 @@
             <input id="name" type="text" required />
           </div>
 
-          <div class="grid">
-            <div class="row">
-              <label for="city">City *</label>
-              <input id="city" type="text" required />
-            </div>
-            <div class="row">
-              <label for="state">State / Province (optional)</label>
-              <input id="state" type="text" maxlength="10" />
-            </div>
+          <div class="row">
+            <label for="city">City *</label>
+            <input id="city" type="text" required />
           </div>
 
           <div class="row">
@@ -592,6 +586,11 @@
             </select>
           </div>
 
+          <div id="state-field-container" class="row">
+            <label for="state">State / Province (optional)</label>
+            <input id="state" type="text" placeholder="State / Province (optional)" />
+          </div>
+
           <fieldset>
             <legend>Categories *</legend>
             <div class="checkboxes" id="category-checkboxes"></div>
@@ -662,6 +661,18 @@
     const turnstileWarning = document.getElementById('turnstile-warning');
     const categoryContainer = document.getElementById('category-checkboxes');
     const reportCount = document.getElementById('report-count');
+    const countryField = document.getElementById('country');
+    const stateFieldContainer = document.getElementById('state-field-container');
+
+    const US_STATES = [
+      'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware',
+      'Florida', 'Georgia', 'Hawaii', 'Idaho', 'Illinois', 'Indiana', 'Iowa', 'Kansas', 'Kentucky',
+      'Louisiana', 'Maine', 'Maryland', 'Massachusetts', 'Michigan', 'Minnesota', 'Mississippi',
+      'Missouri', 'Montana', 'Nebraska', 'Nevada', 'New Hampshire', 'New Jersey', 'New Mexico',
+      'New York', 'North Carolina', 'North Dakota', 'Ohio', 'Oklahoma', 'Oregon', 'Pennsylvania',
+      'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
+      'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
+    ];
 
     let allReports = [];
 
@@ -783,6 +794,29 @@
 
     function updateReportCount(total) {
       reportCount.textContent = total + ' reports and counting!';
+    }
+
+    function renderStateField() {
+      const selectedCountry = (countryField.value || '').trim();
+
+      if (selectedCountry === 'United States of America') {
+        const stateOptions = US_STATES
+          .map((state) => '<option value="' + escapeHTML(state) + '">' + escapeHTML(state) + '</option>')
+          .join('');
+        stateFieldContainer.innerHTML = `
+          <label for="state">State / Province (optional)</label>
+          <select id="state">
+            <option value="">Select a state (optional)</option>
+            ${stateOptions}
+          </select>
+        `;
+        return;
+      }
+
+      stateFieldContainer.innerHTML = `
+        <label for="state">State / Province (optional)</label>
+        <input type="text" id="state" placeholder="State / Province (optional)">
+      `;
     }
 
     function renderReportRows(reports) {
@@ -951,6 +985,7 @@
       addSubmissionTimestamp();
       updateRateLimitUI();
       reportForm.reset();
+      renderStateField();
       resetTurnstileWidget();
       submitMessage.textContent = 'Report submitted successfully.';
       submitMessage.className = 'message success';
@@ -1021,8 +1056,10 @@
       loadReports();
       setupReportActionHandler();
       startRealtimeUpdates();
+      renderStateField();
 
       window.addEventListener('hashchange', renderRoute);
+      countryField.addEventListener('change', renderStateField);
       reportSearch.addEventListener('input', applySearchFilter);
       clearSearch.addEventListener('click', function clearSearchInput() {
         reportSearch.value = '';


### PR DESCRIPTION
### Motivation
- Reorder the submit form location inputs so users enter City, then Country, then State/Province to match the requested UX.
- Make the State input dynamic so that when the user selects `United States of America` the State becomes a controlled `<select id="state">` with full state names, while other countries (or blank) show a text input, preserving existing code that references `document.getElementById('state').value`.

### Description
- Reordered the form fields in `index.html` so the sequence is City → Country → State, and introduced a container `<div id="state-field-container" class="row">` that renders the actual state element.
- Added a `US_STATES` array and a `renderStateField()` function that replaces the container content with either a `<select id="state">` pre-populated with a blank prompt option and all 50 full U.S. state names or an `<input type="text" id="state" placeholder="State / Province (optional)">` for all other countries.
- Wired the dynamic behavior to run on page load, on `country` dropdown `change` events, and after `reportForm.reset()` so the state field always exists with `id="state"` and reflects the current country selection.
- Kept all other JavaScript (e.g., `handleSubmit`, `loadReports`) unchanged and ensured the `state` field id remains `state` in both rendering branches.

### Testing
- Ran a repo inspection and diff checks with `git diff -- index.html` and confirmed the expected modifications to `index.html` succeeded. (passed)
- Verified working tree status with `git status --short` and committed the change with `git commit -m "Add dynamic US state selector and reorder location fields"`. (passed)
- Applied the patch via the repository tooling (`apply_patch`) and created the PR metadata using the `make_pr` helper; no runtime unit tests exist and no browser automation was run. (patch applied and PR metadata generated)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb18f25268832f8859e52fa6b350e1)