### PR TITLE
Add guidance text above reports table

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,6 +153,17 @@
       background: #0f172a;
     }
 
+    .table-guidance {
+      margin: 0.85rem 0 0.65rem;
+      font-size: 0.92rem;
+      color: #cbd5e1;
+    }
+
+    .table-guidance span {
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
     table {
       width: 100%;
       border-collapse: collapse;
@@ -355,6 +366,9 @@
           <button id="clear-search" type="button">Clear</button>
         </div>
         <div id="map"></div>
+        <p class="table-guidance">
+          Click on a state to see results for that state <span>(full list below).</span>
+        </p>
         <div class="table-wrap">
           <table>
             <thead>


### PR DESCRIPTION
### Motivation
- Improve discoverability on the Browse page by giving users a clear hint that the map is interactive and the full results list appears below the map.

### Description
- Inserted a short helper line (`<p class="table-guidance">Click on a state to see results for that state <span>(full list below).</span></p>`) between the map and the reports table and added lightweight styling via a new `.table-guidance` CSS rule so the text matches the page typography.

### Testing
- Ran `git diff --check` and `git status --short`, which reported no issues; no runtime tests were required for this static HTML/CSS update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb267557f4832f9bd676040b2eed7f)