### PR TITLE
Add state dropdown synced with US map selection and filtering

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,11 @@
           <button id="clear-search" type="button">Clear</button>
         </div>
         <p class="table-guidance">
-          Click on a state to see results for that state <span>(full list below).</span>
+          Click on a state to see results for that state, or select a state from the list
+          <select id="browse-state-select" aria-label="Select a state to filter reports">
+            <option value="">Select a state</option>
+          </select>
+          <span>(full list below).</span>
         </p>
         <div id="map"></div>
         
@@ -679,6 +683,7 @@
     const reportCount = document.getElementById('report-count');
     const countryField = document.getElementById('country');
     const stateFieldContainer = document.getElementById('state-field-container');
+    const browseStateSelect = document.getElementById('browse-state-select');
 
     const US_STATES = [
       'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware',
@@ -689,6 +694,8 @@
       'Rhode Island', 'South Carolina', 'South Dakota', 'Tennessee', 'Texas', 'Utah', 'Vermont',
       'Virginia', 'Washington', 'West Virginia', 'Wisconsin', 'Wyoming'
     ];
+
+    window.US_STATES = US_STATES;
 
     let allReports = [];
     window.allReports = allReports;
@@ -721,6 +728,27 @@
         .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
         .join(' ');
     }
+
+
+    function populateBrowseStateSelect() {
+      if (!browseStateSelect) {
+        return;
+      }
+
+      const stateOptions = US_STATES
+        .map((state) => '<option value="' + escapeHTML(state) + '">' + escapeHTML(state) + '</option>')
+        .join('');
+      browseStateSelect.innerHTML = '<option value="">Select a state</option>' + stateOptions;
+    }
+
+    function setStateDropdownValue(stateName) {
+      if (!browseStateSelect) {
+        return;
+      }
+      browseStateSelect.value = stateName || '';
+    }
+
+    window.setStateDropdownValue = setStateDropdownValue;
 
     function filterReportsByState(stateFullName) {
   const searchInput = document.getElementById('report-search');
@@ -1022,6 +1050,7 @@
       updateRateLimitUI();
       reportForm.reset();
       renderStateField();
+      populateBrowseStateSelect();
       resetTurnstileWidget();
       submitMessage.textContent = 'Report submitted successfully.';
       submitMessage.className = 'message success';
@@ -1093,14 +1122,38 @@
       setupReportActionHandler();
       startRealtimeUpdates();
       renderStateField();
+      populateBrowseStateSelect();
 
       window.addEventListener('hashchange', renderRoute);
       countryField.addEventListener('change', renderStateField);
       reportSearch.addEventListener('input', applySearchFilter);
       clearSearch.addEventListener('click', function clearSearchInput() {
         reportSearch.value = '';
+        setStateDropdownValue('');
+        if (typeof window.clearSelectedMapState === 'function') {
+          window.clearSelectedMapState();
+        }
         applySearchFilter();
       });
+      if (browseStateSelect) {
+        browseStateSelect.addEventListener('change', function onStateSelectChange() {
+          const selectedState = browseStateSelect.value;
+          if (!selectedState) {
+            if (typeof window.clearSelectedMapState === 'function') {
+              window.clearSelectedMapState();
+            }
+            reportSearch.value = '';
+            applySearchFilter();
+            return;
+          }
+
+          if (typeof window.selectStateOnMapByName === 'function') {
+            window.selectStateOnMapByName(selectedState);
+          } else {
+            filterReportsByState(selectedState);
+          }
+        });
+      }
       reportForm.addEventListener('submit', handleSubmit);
     }
 

--- a/usmap.js
+++ b/usmap.js
@@ -17,7 +17,9 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
 (function () {
   var DEFAULT_STATE_COLOR = "#2d3748";
   var HOVER_STATE_COLOR = "#a855f7";
+  var ACTIVE_STATE_COLOR = "#7c3aed";
   var overridesApplied = false;
+  var selectedStateId = null;
 
   function escapeHtml(value) {
     return String(value)
@@ -34,6 +36,59 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
     return stateSpecific[stateId] && stateSpecific[stateId].name
       ? stateSpecific[stateId].name
       : stateId;
+  }
+
+  function getStateIdByName(stateName) {
+    var mapdata = window.simplemaps_usmap_mapdata || {};
+    var stateSpecific = mapdata.state_specific || {};
+    var normalized = String(stateName || "").trim().toLowerCase();
+    var stateId;
+
+    for (stateId in stateSpecific) {
+      if (
+        Object.prototype.hasOwnProperty.call(stateSpecific, stateId) &&
+        stateSpecific[stateId] &&
+        String(stateSpecific[stateId].name || "").trim().toLowerCase() === normalized
+      ) {
+        return stateId;
+      }
+    }
+
+    return null;
+  }
+
+  function setSelectedState(stateId) {
+    if (selectedStateId && selectedStateId !== stateId) {
+      setStateFill(selectedStateId, DEFAULT_STATE_COLOR);
+    }
+
+    selectedStateId = stateId || null;
+
+    if (selectedStateId) {
+      setStateFill(selectedStateId, ACTIVE_STATE_COLOR);
+    }
+  }
+
+  function syncStateDropdown(stateName) {
+    if (typeof window.setStateDropdownValue === "function") {
+      window.setStateDropdownValue(stateName || "");
+    }
+  }
+
+  function selectState(stateId, shouldFilter) {
+    if (!stateId) {
+      setSelectedState(null);
+      syncStateDropdown("");
+      return;
+    }
+
+    setSelectedState(stateId);
+    var stateName = getStateName(stateId);
+    syncStateDropdown(stateName);
+
+    if (shouldFilter && typeof window.filterReportsByState === "function") {
+      window.filterReportsByState(stateName);
+    }
   }
 
   function getReportCount(stateName) {
@@ -207,7 +262,11 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
     });
 
     chainHook("out_state", function (stateId) {
-      setStateFill(stateId, DEFAULT_STATE_COLOR);
+      if (selectedStateId && stateId === selectedStateId) {
+        setStateFill(stateId, ACTIVE_STATE_COLOR);
+      } else {
+        setStateFill(stateId, DEFAULT_STATE_COLOR);
+      }
       hideTooltip();
     });
 
@@ -218,10 +277,7 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
       if (event && typeof event.stopPropagation === "function") {
         event.stopPropagation();
       }
-      var stateName = getStateName(stateId);
-      if (typeof window.filterReportsByState === "function") {
-        window.filterReportsByState(stateName);
-      }
+      selectState(stateId, true);
     });
 
     var container = getMapContainer();
@@ -229,6 +285,15 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
       container.addEventListener("mousemove", moveTooltip);
       container.addEventListener("mouseleave", hideTooltip);
     }
+
+    window.selectStateOnMapByName = function (stateName) {
+      var stateId = getStateIdByName(stateName);
+      selectState(stateId, true);
+    };
+
+    window.clearSelectedMapState = function () {
+      selectState(null, false);
+    };
 
     window.addEventListener("resize", ensureMapResponsive);
     ensureMapResponsive();


### PR DESCRIPTION
### Motivation

- Make the browse guidance more discoverable by adding a state dropdown so users can select a state instead of (or in addition to) clicking the map. 
- Keep the UI controls and map in sync so selecting a state from the dropdown highlights that state on the map and applies the same report filtering as a map click.

### Description

- Inserted a 50-state dropdown into the browse guidance in `index.html` and added `populateBrowseStateSelect` and `setStateDropdownValue` helpers to populate and control it. 
- Wired dropdown events to trigger the existing filter flow so selecting a state calls the same filter logic (via `filterReportsByState` or the map helper) and clearing search clears the dropdown and map selection. 
- Exposed `window.US_STATES` and a small bridge so the UI can programmatically set the dropdown value from other scripts. 
- Extended `usmap.js` to track a selected state and keep it highlighted (`ACTIVE_STATE_COLOR`), to map state names back to state IDs, and to provide `selectStateOnMapByName` and `clearSelectedMapState` functions so the dropdown and map remain bidirectionally synchronized (map clicks update the dropdown; dropdown selection updates the map and triggers filtering).

### Testing

- Ran a static syntax check with `node --check usmap.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb2a8cf2f8832f9e1b9da3491ee565)