### PR TITLE
Remove default New York and Anchorage map highlights

### DIFF
--- a/mapdata.js
+++ b/mapdata.js
@@ -472,25 +472,7 @@ var simplemaps_usmap_mapdata={
       hide: "yes"
     }
   },
-  locations: {
-    "0": {
-      name: "New York",
-      lat: 40.71,
-      lng: -74,
-      description: "default",
-      color: "default",
-      url: "default",
-      type: "default",
-      size: "default"
-    },
-    "1": {
-      name: "Anchorage",
-      lat: 61.2180556,
-      lng: -149.9002778,
-      color: "default",
-      type: "circle"
-    }
-  },
+  locations: {},
   labels: {
     NH: {
       parent_id: "NH",


### PR DESCRIPTION
### Motivation
- Remove the hardcoded location markers (the pink square/circle highlights) that appear for New York (city) and Anchorage so the browse page map no longer shows those default highlights.

### Description
- Replaced the `locations` block in `mapdata.js` with an empty object (`locations: {}`) to remove the two default markers for New York and Anchorage.

### Testing
- Ran `node -c mapdata.js` to validate the modified file and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb67b09e00832fb319d415fd1b2262)