### PR TITLE
Hide lingering pink map markers by disabling default locations

### DIFF
--- a/index.html
+++ b/index.html
@@ -1236,7 +1236,7 @@
     init();
   </script>
   <!-- At the end of your <body>, before the closing </body> tag -->
-<script src="mapdata.js?v=2026-04-24-1"></script>
+<script src="mapdata.js?v=2026-04-24-2"></script>
 <script src="usmap.js?v=2026-04-24-1"></script>
 
 

--- a/mapdata.js
+++ b/mapdata.js
@@ -28,7 +28,7 @@ var simplemaps_usmap_mapdata={
     location_border: 2,
     location_hover_border: 2.5,
     all_locations_inactive: "no",
-    all_locations_hidden: "no",
+    all_locations_hidden: "yes",
     
 		//Label defaults
 		label_color: "#ffffff",


### PR DESCRIPTION
### Motivation
- Prevent lingering SimpleMaps location markers (e.g. the Anchorage and New York City pink artifacts) from rendering and ensure browsers fetch the updated map config.

### Description
- Set `all_locations_hidden: "yes"` in `mapdata.js` to globally hide SimpleMaps location markers and updated the `mapdata.js` cache-busting query string in `index.html` so clients will load the new settings.

### Testing
- Inspected files with `rg`/`sed`/`nl` to confirm `mapdata.js` now contains `all_locations_hidden: "yes"` and `index.html` references `mapdata.js?v=2026-04-24-2`, and these checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6933300c832fbec8a3e56d3d1cd4)