### PR TITLE
Update browse page instruction copy for map/list usage

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
           <button id="clear-search" type="button">Clear</button>
         </div>
         <p class="table-guidance">
-          Click on a state to see results for that state, or select a state from the list
+          Select a state from the list or click show map to see results for specific locations. (More maps and options will be coming soon, including a world map).
           <select id="browse-state-select" aria-label="Select a state to filter reports">
             <option value="">Select a state</option>
           </select>


### PR DESCRIPTION
### Motivation
- Clarify the Browse page helper text so users know they can use the state dropdown or map and to announce upcoming maps (including a world map).

### Description
- Replace the guidance sentence in `index.html` on the Browse page with: "Select a state from the list or click show map to see results for specific locations. (More maps and options will be coming soon, including a world map)."

### Testing
- Verified the updated text in `index.html` by searching and inspecting the file with `rg` and `nl`, and confirmed the new copy is present; no automated unit tests were required for this static HTML text change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb6ee9a24c832facce9b053aa9c4b8)