### PR TITLE
Unify header report-count formatting and add dynamic count on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -215,7 +215,7 @@
     <div class="container header-inner">
       <div class="site-title-wrap">
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
-        <p class="report-count">Browse reports and counting...</p>
+        <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
       <nav>
         <a href="index.html#/browse" class="nav-link">Browse</a>
@@ -288,5 +288,35 @@
       <span>Open source</span>
     </div>
   </footer>
+
+  <script>
+    async function loadReportCount() {
+      const reportCount = document.getElementById('report-count');
+      if (!reportCount) {
+        return;
+      }
+
+      const WORKER_URL = 'https://api.namehim.app/filtered-reports';
+
+      try {
+        const response = await fetch(WORKER_URL);
+        if (!response.ok) {
+          throw new Error('Worker returned ' + response.status);
+        }
+
+        const reports = await response.json();
+        if (!Array.isArray(reports)) {
+          throw new Error('Worker did not return an array');
+        }
+
+        reportCount.textContent = reports.length + ' reports and counting...';
+      } catch (error) {
+        console.error('Failed to load report count:', error);
+        reportCount.textContent = '0 reports and counting...';
+      }
+    }
+
+    loadReportCount();
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@
     }
 
     function updateReportCount(total) {
-      reportCount.textContent = total + ' reports and counting!';
+      reportCount.textContent = total + ' reports and counting...';
     }
 
     function renderStateField() {


### PR DESCRIPTION
### Motivation
- Make the report-count header wording consistent across the Browse/Submit flow and the About page by replacing the exclamation mark with an ellipsis and ensure the About header shows the actual, live report count.

### Description
- Changed the shared header counter text in `index.html` so `updateReportCount` uses `...` instead of `!` when rendering the count.
- Replaced the static About header copy in `about.html` with an element that has `id="report-count"` so it can be updated programmatically.
- Added a small client-side script to `about.html` that fetches `https://api.namehim.app/filtered-reports`, computes `reports.length`, and writes `N reports and counting...` with a safe fallback of `0 reports and counting...` on failure.
- Minor housekeeping: updated files and committed the changes with a concise commit message.

### Testing
- Ran `git diff --check` which produced no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec982547b0832f8e05205cde058da9)