### PR TITLE
Fix world and US map toggle rendering conflicts

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,12 +355,8 @@
     }
 
     #world-map {
-  width: 100%;
-  height: 450px;
-  margin-bottom: 1rem;
-  background: #1f2937;
-  border-radius: 0.5rem;
-}
+      display: none;
+    }
 
     footer {
       border-top: 1px solid var(--border);
@@ -486,7 +482,7 @@
         <div class="map-toggle-wrap">
   <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
 </div>
-<div id="world-map" style="display: none; width: 100%; height: 450px; margin-bottom: 1rem; background: #1f2937; border-radius: 0.5rem;"></div>
+<div id="world-map"></div>
         
         <div class="table-wrap">
           <table>
@@ -1486,6 +1482,10 @@
         return;
       }
 
+      if (isVisible && typeof setWorldMapVisibility === 'function') {
+        setWorldMapVisibility(false);
+      }
+
       mapContainer.style.display = isVisible ? 'block' : 'none';
       toggleMapBtn.textContent = isVisible ? 'Hide US Map' : 'Show US Map';
       toggleMapBtn.setAttribute('aria-expanded', String(isVisible));
@@ -1622,14 +1622,32 @@ const WORLD_MAP_VISIBILITY_KEY = 'namehim_world_map_visible';
 
 function setWorldMapVisibility(isVisible, persistPreference = true) {
   if (!worldMapContainer || !toggleWorldMapBtn) return;
+
+  if (isVisible && typeof setMapVisibility === 'function') {
+    setMapVisibility(false);
+  }
+
   worldMapContainer.style.display = isVisible ? 'block' : 'none';
   toggleWorldMapBtn.textContent = isVisible ? 'Hide World Map' : 'Show World Map';
   toggleWorldMapBtn.setAttribute('aria-expanded', String(isVisible));
   if (persistPreference) {
     localStorage.setItem(WORLD_MAP_VISIBILITY_KEY, isVisible ? '1' : '0');
   }
-  if (isVisible && window.simplemaps_worldmap && typeof window.simplemaps_worldmap.refresh === 'function') {
-    window.simplemaps_worldmap.refresh();
+  if (isVisible) {
+    window.requestAnimationFrame(function onWorldMapShow() {
+      if (
+        window.simplemaps_worldmap &&
+        typeof window.simplemaps_worldmap.refresh === 'function'
+      ) {
+        window.simplemaps_worldmap.refresh();
+      }
+      if (
+        window.simplemaps_worldmap &&
+        typeof window.simplemaps_worldmap.resize === 'function'
+      ) {
+        window.simplemaps_worldmap.resize();
+      }
+    });
   }
 }
 


### PR DESCRIPTION
### Motivation
- Users reported incorrect world/US map behavior: a blank box below the world map on mobile, and the world map not appearing reliably on desktop.
- Investigation showed the world map container had fixed inline sizing and the two map toggle flows could leave both maps in inconsistent states.
- The change aims to let the SimpleMaps library size the world map responsively and to avoid overlapping/competing visibility between maps.

### Description
- Removed the fixed inline sizing/background for `#world-map` and set the CSS to keep it hidden by default so the map library can determine dimensions responsively. 
- Simplified the world map markup by replacing the inline-styled element with an empty `#world-map` container.
- Made map toggles mutually exclusive by updating `setMapVisibility` and `setWorldMapVisibility` so showing one map hides the other. 
- When the world map is shown, added a `requestAnimationFrame` callback that calls `window.simplemaps_worldmap.refresh()` and `window.simplemaps_worldmap.resize()` (when available) to force a proper re-render after becoming visible.

### Testing
- Verified file contents and the applied diff with static inspections using `nl -ba index.html | sed -n '340,510p'` and `nl -ba index.html | sed -n '1468,1668p'`, which showed the CSS, markup, and toggle logic updates as expected. All inspections succeeded. 
- Confirmed search-based checks for map-related identifiers with `rg -n "world-map|simplemaps_worldmap_mapdata|toggle-world-map-btn|WORLD_MAP" index.html wmapdata.js worldmap.js` returned the expected locations and references. 
- Confirmed the patch application produced success output and that the working tree reflects the changes; a runtime/browser render verification was not performed here because a browser rendering check/screenshot tool is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecac40b360832fbddbd6919053ad5a)