### PR TITLE
Fix desktop world-map toggle by cache-busting assets and adding runtime safeguard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1718,8 +1718,14 @@ initWorldMapInteractions();
   <!-- At the end of your <body>, before the closing </body> tag -->
 <script src="mapdata.js?v=2026-04-24-3"></script>
 <script src="usmap.js?v=2026-04-24-4"></script>
-<script src="wmapdata.js"></script>
-<script src="worldmap.js"></script>
+<script src="wmapdata.js?v=2026-04-25-1"></script>
+<script>
+  if (window.simplemaps_worldmap_mapdata && window.simplemaps_worldmap_mapdata.main_settings) {
+    window.simplemaps_worldmap_mapdata.main_settings.div = 'world-map';
+    window.simplemaps_worldmap_mapdata.main_settings.auto_load = 'yes';
+  }
+</script>
+<script src="worldmap.js?v=2026-04-25-1"></script>
 
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Desktop was loading stale world-map JS/data while newer logic (and mobile) used updated assets, causing the US/world map toggle to render the wrong map or a blank area. 
- The change ensures the world-map assets and config are consistent across desktop and mobile to avoid container binding mismatches.

### Description
- Added cache-busting query params to the world map includes by updating `wmapdata.js` and `worldmap.js` script tags in `index.html` to include `?v=2026-04-25-1`.
- Inserted a small inline safeguard before loading `worldmap.js` that forces `window.simplemaps_worldmap_mapdata.main_settings.div = 'world-map'` and `main_settings.auto_load = 'yes'` to ensure the world map binds to the correct container.
- Changes are limited to `index.html` (script includes + inline script) and do not modify the map library or data files themselves.

### Testing
- Parsed `index.html` with Python's `html.parser` (`HTMLParser`) to validate HTML syntax and the updated script block, which succeeded.
- Verified the diff of `index.html` shows only the intended script tag updates and the inserted safeguard block using a repository diff check, which matched expectations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb1e9c74c832fb0f0b56ea2985d8a)