### PR TITLE
Highlight regions on hover and add region tooltips guiding country selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -1725,7 +1725,7 @@ initWorldMapInteractions();
     window.simplemaps_worldmap_mapdata.main_settings.auto_load = 'yes';
   }
 </script>
-<script src="worldmap.js?v=2026-04-25-1"></script>
+<script src="worldmap.js?v=2026-04-25-2"></script>
 
 </body>
 </html>

--- a/worldmap.js
+++ b/worldmap.js
@@ -66,6 +66,14 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
       : countryId;
   }
 
+  function getRegionName(regionId) {
+    var mapdata = window.simplemaps_worldmap_mapdata || {};
+    var regions = mapdata.regions || {};
+    return regions[regionId] && regions[regionId].name
+      ? regions[regionId].name
+      : regionId;
+  }
+
   function getCountryReportCount(countryName) {
     var reports = Array.isArray(window.allReports) ? window.allReports : [];
     var target = normalizeText(countryName);
@@ -74,6 +82,33 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
 
     for (i = 0; i < reports.length; i += 1) {
       if (normalizeText(reports[i] && reports[i].country) === target) {
+        count += 1;
+      }
+    }
+
+    return count;
+  }
+
+  function getRegionReportCount(regionId) {
+    var reports = Array.isArray(window.allReports) ? window.allReports : [];
+    var mapdata = window.simplemaps_worldmap_mapdata || {};
+    var regions = mapdata.regions || {};
+    var states = (regions[regionId] && regions[regionId].states) || [];
+    var countrySpecific = mapdata.state_specific || {};
+    var countryLookup = {};
+    var i;
+    var countryId;
+    var count = 0;
+
+    for (i = 0; i < states.length; i += 1) {
+      countryId = states[i];
+      if (countrySpecific[countryId] && countrySpecific[countryId].name) {
+        countryLookup[normalizeText(countrySpecific[countryId].name)] = true;
+      }
+    }
+
+    for (i = 0; i < reports.length; i += 1) {
+      if (countryLookup[normalizeText(reports[i] && reports[i].country)]) {
         count += 1;
       }
     }
@@ -193,6 +228,19 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     tooltip.style.display = "block";
   }
 
+  function showRegionTooltip(regionId) {
+    var tooltip = ensureTooltip();
+    var regionName = getRegionName(regionId);
+    var count = getRegionReportCount(regionId);
+    tooltip.innerHTML =
+      "<div>" +
+      escapeHtml(regionName) +
+      " <span style='opacity:.8'>(click to select individual countries)</span></div><div>Reports: " +
+      count +
+      "</div>";
+    tooltip.style.display = "block";
+  }
+
   function hideTooltip() {
     ensureTooltip().style.display = "none";
   }
@@ -304,8 +352,26 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     }
 
     chainHook("complete", function () {
+      var regionId;
+
       disableCountryUrls();
       ensureMapLayout();
+
+      if (map && map.regions) {
+        for (regionId in map.regions) {
+          if (
+            Object.prototype.hasOwnProperty.call(map.regions, regionId) &&
+            map.regions[regionId] &&
+            map.regions[regionId].attr
+          ) {
+            map.regions[regionId].attr({
+              cursor: "pointer",
+              fill: "none",
+              "fill-opacity": 0
+            });
+          }
+        }
+      }
     });
 
     chainHook("over_state", function (countryId) {
@@ -319,6 +385,26 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
         setCountryFill(countryId, ACTIVE_COUNTRY_COLOR);
       } else {
         setCountryFill(countryId, DEFAULT_COUNTRY_COLOR);
+      }
+      hideTooltip();
+    });
+
+    chainHook("over_region", function (regionId) {
+      if (map && map.regions && map.regions[regionId] && map.regions[regionId].attr) {
+        map.regions[regionId].attr({
+          fill: HOVER_COUNTRY_COLOR,
+          "fill-opacity": 0.28
+        });
+      }
+      showRegionTooltip(regionId);
+    });
+
+    chainHook("out_region", function (regionId) {
+      if (map && map.regions && map.regions[regionId] && map.regions[regionId].attr) {
+        map.regions[regionId].attr({
+          fill: "none",
+          "fill-opacity": 0
+        });
       }
       hideTooltip();
     });


### PR DESCRIPTION
### Motivation
- Make continental region overlays on the world map more noticeable on hover and provide the same quick informational tooltip people get for individual countries, including an instruction to click to select countries.

### Description
- Added `getRegionName` and `getRegionReportCount` helpers and a `showRegionTooltip` renderer to produce region tooltips that show name, report count, and the text `(click to select individual countries)`; these live in `worldmap.js`.
- Hooked into `over_region` and `out_region` to set region fill to the purple hover color and restore the overlay on mouseout, and to show/hide the new region tooltip.
- On map `complete`, initialized region shapes (pointer cursor and transparent fill) so hover highlighting is visible and clickable across browsers.
- Bumped the `worldmap.js` cache-busting query string in `index.html` so clients load the updated interaction script immediately.

### Testing
- Ran `node --check worldmap.js` to validate the updated script and it completed with no syntax errors (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb31ebf5c832f9880f8cbc803b5c0)