### PR TITLE
Remove SimpleMaps branding links from US and world map overlays

### DIFF
--- a/usmap.js
+++ b/usmap.js
@@ -223,6 +223,24 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
     tooltip.style.display = "none";
   }
 
+
+  function removeSimpleMapsBranding() {
+    var container = getMapContainer();
+    var links;
+    var i;
+
+    if (!container) {
+      return;
+    }
+
+    links = container.querySelectorAll('a[href*="simplemaps.com"], a[title*="SimpleMaps"], a[title*="Simplemaps"]');
+    for (i = 0; i < links.length; i += 1) {
+      if (links[i] && links[i].parentNode) {
+        links[i].parentNode.removeChild(links[i]);
+      }
+    }
+  }
+
   function chainHook(hookName, handler) {
     var map = window.simplemaps_usmap;
     if (!map || !map.hooks) {
@@ -294,6 +312,7 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
       disableStateUrls();
       ensureMapResponsive();
       normalizeMapPointerEvents();
+      removeSimpleMapsBranding();
     });
 
     chainHook("over_state", function (stateId) {
@@ -345,6 +364,7 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
     ensureMapResponsive();
     refreshMapHitAreas();
     normalizeMapPointerEvents();
+    removeSimpleMapsBranding();
     return true;
   }
 

--- a/worldmap.js
+++ b/worldmap.js
@@ -245,6 +245,23 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     ensureTooltip().style.display = "none";
   }
 
+  function removeSimpleMapsBranding() {
+    var container = getMapContainer();
+    var links;
+    var i;
+
+    if (!container) {
+      return;
+    }
+
+    links = container.querySelectorAll('a[href*="simplemaps.com"], a[title*="SimpleMaps"], a[title*="Simplemaps"]');
+    for (i = 0; i < links.length; i += 1) {
+      if (links[i] && links[i].parentNode) {
+        links[i].parentNode.removeChild(links[i]);
+      }
+    }
+  }
+
   function moveTooltip(event) {
     var tooltip = ensureTooltip();
     tooltip.style.left = event.clientX + 14 + "px";
@@ -356,6 +373,7 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
 
       disableCountryUrls();
       ensureMapLayout();
+      removeSimpleMapsBranding();
 
       if (map && map.regions) {
         for (regionId in map.regions) {
@@ -428,6 +446,7 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     window.clearSelectedWorldCountry = clearCountrySelection;
 
     ensureMapLayout();
+    removeSimpleMapsBranding();
     return true;
   }
 


### PR DESCRIPTION
### Motivation
- Prevent the SimpleMaps logo/link from appearing in the bottom-right of both the US and world maps by removing the generated anchor element and its link after the maps render.

### Description
- Added a `removeSimpleMapsBranding()` helper to `usmap.js` and `worldmap.js` that finds and removes anchor nodes matching `a[href*="simplemaps.com"]` and title variants in the map container, with a guard if the container is missing.
- Invoke `removeSimpleMapsBranding()` during map initialization and on the map `complete` hook so the branding/link is removed both on first load and after render cycles in `applyMapOverrides()`/`applyOverrides()`.
- Kept existing override logic intact (`disable_*Urls`, tooltip hooks, pointer normalization, layout/resize handling) and only added the branding removal calls in the appropriate lifecycle points.

### Testing
- Performed JavaScript syntax checks with `node --check usmap.js` and `node --check worldmap.js`, both succeeded. 
- Verified the helper is registered and invoked from the map `complete` hooks and final initialization paths by inspecting the modified files (`usmap.js` and `worldmap.js`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb3b82d7c832fb2e17e8e8ce21095)