### PR TITLE
Treat US naming variants as one country for world map counts

### DIFF
--- a/worldmap.js
+++ b/worldmap.js
@@ -18,6 +18,11 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
   var ACTIVE_COUNTRY_COLOR = "#7c3aed";
   var applied = false;
   var selectedCountryId = null;
+  var COUNTRY_COUNT_ALIASES = {
+    "united states of america": "united states",
+    usa: "united states",
+    us: "united states"
+  };
 
   function normalizeText(value) {
     return String(value || "")
@@ -74,14 +79,19 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
       : regionId;
   }
 
+  function normalizeCountryForCount(countryName) {
+    var normalized = normalizeText(countryName);
+    return COUNTRY_COUNT_ALIASES[normalized] || normalized;
+  }
+
   function getCountryReportCount(countryName) {
     var reports = Array.isArray(window.allReports) ? window.allReports : [];
-    var target = normalizeText(countryName);
+    var target = normalizeCountryForCount(countryName);
     var count = 0;
     var i;
 
     for (i = 0; i < reports.length; i += 1) {
-      if (normalizeText(reports[i] && reports[i].country) === target) {
+      if (normalizeCountryForCount(reports[i] && reports[i].country) === target) {
         count += 1;
       }
     }
@@ -103,12 +113,12 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     for (i = 0; i < states.length; i += 1) {
       countryId = states[i];
       if (countrySpecific[countryId] && countrySpecific[countryId].name) {
-        countryLookup[normalizeText(countrySpecific[countryId].name)] = true;
+        countryLookup[normalizeCountryForCount(countrySpecific[countryId].name)] = true;
       }
     }
 
     for (i = 0; i < reports.length; i += 1) {
-      if (countryLookup[normalizeText(reports[i] && reports[i].country)]) {
+      if (countryLookup[normalizeCountryForCount(reports[i] && reports[i].country)]) {
         count += 1;
       }
     }


### PR DESCRIPTION
### Motivation
- Fix inaccurate "United States" report totals on the world map caused by different country name variants (e.g. "United States of America", "USA", "US") not matching the map label.

### Description
- Add a small alias map `COUNTRY_COUNT_ALIASES` and a helper `normalizeCountryForCount` in `worldmap.js` to map common variants to a single key.
- Update `getCountryReportCount` to use the alias-aware normalization when matching report `country` values.
- Update `getRegionReportCount` to build region lookups and test report countries using the same alias-aware normalization so regional aggregates include U.S. variants consistently.
- All changes were made in `worldmap.js` (normalization + counting logic) and reuse the existing `resolveCountrySelection` pattern for consistency.

### Testing
- Checked the modified file syntax with `node --check worldmap.js`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb468ce9c832fb6ba6c280a0543eb)