### PR TITLE
Place US and World map toggle buttons side by side

### DIFF
--- a/index.html
+++ b/index.html
@@ -346,8 +346,21 @@
       margin-bottom: 0.65rem;
     }
 
+    .map-toggle-row {
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      margin-bottom: 0.65rem;
+    }
+
+    .map-toggle-row .map-toggle-wrap {
+      margin-bottom: 0;
+      flex: 1;
+    }
+
     .map-toggle-btn {
-      min-width: 10rem;
+      min-width: 0;
+      flex: 1;
     }
 
     #map {
@@ -483,15 +496,16 @@
           </span>
           <span>(full list below).</span>
         </p>
-        <div class="map-toggle-wrap">
-          <button id="toggle-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="map">Show US Map</button>
+        <div class="map-toggle-row">
+          <div class="map-toggle-wrap">
+            <button id="toggle-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="map">Show US Map</button>
+          </div>
+          <div class="map-toggle-wrap">
+            <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
+          </div>
         </div>
         <div id="map"></div>
-
-        <div class="map-toggle-wrap">
-  <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
-</div>
-<div id="world-map"></div>
+        <div id="world-map"></div>
         
         <div class="table-wrap">
           <table>


### PR DESCRIPTION
### Motivation
- Users expect the two map toggle controls to appear horizontally together instead of stacked, so the `Show World Map` button should be beside the `Show US Map` button to improve layout and discoverability.

### Description
- Added a new `.map-toggle-row` flex container and moved both toggle buttons into it so they render side-by-side in the browse page markup in `index.html`.
- Adjusted `.map-toggle-btn` to use `flex: 1` and `min-width: 0` and added `.map-toggle-row .map-toggle-wrap { flex: 1; }` so both buttons share available width on narrow and wide viewports.
- Kept both map containers (`#map` and `#world-map`) and preserved button IDs and ARIA attributes (`toggle-map-btn`, `toggle-world-map-btn`, `aria-controls`) so existing JavaScript toggle logic is unchanged.
- This change is layout-only and does not modify any JavaScript or map behavior in `usmap.js`/`worldmap.js`.

### Testing
- Applied the patch and verified the file update with `git status --short`, which succeeded.
- Confirmed the commit and patch contents using `git show --name-only --oneline --stat HEAD`, which succeeded.
- Verified the modified sections by inspecting `index.html` to ensure IDs and ARIA attributes remain intact and the new CSS rules are present, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb574cab4832fa5b6ecc6be0c45cc)