### PR TITLE
Normalize US country variants in world map and browse filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -888,6 +888,34 @@
         .join(' ');
     }
 
+    const COUNTRY_FILTER_ALIASES = {
+      'united states': 'united states',
+      'united states america': 'united states',
+      'u s': 'united states',
+      'u s a': 'united states',
+      usa: 'united states',
+      us: 'united states'
+    };
+
+    function normalizeCountryForFiltering(value) {
+      const normalized = String(value || '')
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .toLowerCase()
+        .replace(/&/g, ' and ')
+        .replace(/['’`]/g, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/\b(the|of|and|republic|state|islands?)\b/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+      return COUNTRY_FILTER_ALIASES[normalized] || normalized;
+    }
+
+    function isUnitedStatesCountryValue(value) {
+      return normalizeCountryForFiltering(value) === 'united states';
+    }
+
 
     function populateBrowseStateSelect() {
       if (!browseStateSelect) {
@@ -926,7 +954,7 @@
       }
 
       const selectedCountry = String(browseCountrySelect.value || '').trim().toLowerCase();
-      const shouldShowStateFilter = !selectedCountry || selectedCountry === 'united states of america';
+      const shouldShowStateFilter = !selectedCountry || isUnitedStatesCountryValue(selectedCountry);
 
       browseStateSelectWrap.classList.toggle('hidden', !shouldShowStateFilter);
 
@@ -1316,11 +1344,11 @@ function filterReportsByState(stateFullName) {
         const blob = [report.name, report.city, report.state, report.country]
           .map((item) => String(item || '').toLowerCase())
           .join(' ');
-        const reportCountry = String(report.country || '').trim().toLowerCase();
+        const reportCountry = normalizeCountryForFiltering(report.country);
         const reportState = String(report.state || '').trim().toLowerCase();
 
         const matchesQuery = !query || blob.includes(query);
-        const matchesCountry = !selectedCountry || reportCountry === selectedCountry;
+        const matchesCountry = !selectedCountry || reportCountry === normalizeCountryForFiltering(selectedCountry);
         const matchesState = !selectedState || reportState === selectedState;
 
         return matchesQuery && matchesCountry && matchesState;

--- a/worldmap.js
+++ b/worldmap.js
@@ -21,7 +21,10 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
   var brandingObserver = null;
   var cleanupIntervalId = null;
   var COUNTRY_COUNT_ALIASES = {
-    "united states of america": "united states",
+    "united states": "united states",
+    "united states america": "united states",
+    "u s": "united states",
+    "u s a": "united states",
     usa: "united states",
     us: "united states"
   };


### PR DESCRIPTION
### Motivation
- Reports for the United States were scattered across multiple stored country labels (e.g. `USA`, `United States of America`, `U.S.`), so map counts and browse filters under-counted U.S. reports. 

### Description
- Added canonical country normalization and alias table used by the browse UI in `index.html` (`COUNTRY_FILTER_ALIASES`, `normalizeCountryForFiltering`, `isUnitedStatesCountryValue`) and switched filtering and state-dropdown logic to use the normalized form instead of strict string equality. 
- Updated the world map country-count alias table in `worldmap.js` (`COUNTRY_COUNT_ALIASES`) to include additional normalized variants (`"united states","united states america","u s","u s a", etc.`) so counting logic collapses common U.S. variants into the same canonical key. 
- Replaced places where country comparison was previously plain `.toLowerCase()` equality to use the new normalization helper so both map counting and browse filtering behave consistently. 
- Changes touch `index.html` and `worldmap.js` and preserve existing tooltip/display logic while using the canonicalized country keys for matching and UI decisions. 

### Testing
- Ran `node --check worldmap.js` to validate the modified `worldmap.js` syntax, which succeeded. 
- Executed a small Node normalization check that exercises common U.S. variants (e.g. `United States of America`, `United States`, `USA`, `U.S.A.`, `U.S.`) against the new normalization function and confirmed all variants map to `united states` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecb963246c832f88b74dc12495fe0d)