### PR TITLE
Fix routing and community story handler scope in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,7 +500,7 @@
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>
-        <a href="#/voices" class="nav-link" data-route="#/community">Community</a>
+        <a href="#/community" class="nav-link" data-route="#/community">Community</a>
         <a href="about.html" class="nav-link">About</a>
       </nav>
     </div>
@@ -844,7 +844,7 @@
     const routes = {
   '#/browse': 'page-browse',
   '#/submit': 'page-submit',
-  '#/voices': 'page-community'
+  '#/community': 'page-community'
 };
 
     const CATEGORIES = [
@@ -1102,7 +1102,7 @@ function filterReportsByState(stateFullName) {
 
     function getCurrentRoute() {
       const hashPath = getHashPath();
-      return ROUTES[hashPath] ? hashPath : '#/browse';
+      return routes[hashPath] ? hashPath : '#/browse';
     }
 
     function getReportIdFromUrl() {
@@ -1224,24 +1224,6 @@ function filterReportsByState(stateFullName) {
     }
 
     function renderRoute() {
-      const route = getCurrentRoute();
-
-      if (getHashPath() !== route) {
-        window.location.hash = route;
-        return;
-      }
-
-      pageBrowse.classList.toggle('active', route === '#/browse');
-      pageSubmit.classList.toggle('active', route === '#/submit');
-
-      document.querySelectorAll('[data-route]').forEach((link) => {
-        link.classList.toggle('active', link.getAttribute('data-route') === route);
-      });
-
-      updateBrowseViewFromRoute();
-    }
-
-    function renderRoute() {
   const route = getCurrentRoute();
 
   if (getHashPath() !== route) {
@@ -1251,8 +1233,8 @@ function filterReportsByState(stateFullName) {
 
   pageBrowse.classList.toggle('active', route === '#/browse');
   pageSubmit.classList.toggle('active', route === '#/submit');
-  const voicesPage = document.getElementById('page-voices');
-  if (voicesPage) voicesPage.classList.toggle('active', route === '#/voices');
+  const communityPage = document.getElementById('page-community');
+  if (communityPage) communityPage.classList.toggle('active', route === '#/community');
 
   document.querySelectorAll('[data-route]').forEach((link) => {
     link.classList.toggle('active', link.getAttribute('data-route') === route);
@@ -1260,7 +1242,7 @@ function filterReportsByState(stateFullName) {
 
   updateBrowseViewFromRoute();
 
-  if (route === '#/voices') {
+  if (route === '#/community') {
     loadApprovedStories();
   }
 }
@@ -1564,19 +1546,7 @@ function addStoryTimestamp() {
         .map((input) => input.value);
     }
 
-    async function handleSubmit(event) {
-      event.preventDefault();
-      submitMessage.textContent = '';
-      submitMessage.className = 'message';
-      turnstileWarning.classList.add('hidden');
-
-      if (updateRateLimitUI()) {
-        submitMessage.textContent = 'Rate limit reached. Please wait before submitting again.';
-        submitMessage.className = 'message error';
-        return;
-      }
-
-      async function submitStory(event) {
+    async function submitStory(event) {
   event.preventDefault();
   storyMessage.textContent = '';
   storyTurnstileWarning.classList.add('hidden');
@@ -1624,6 +1594,18 @@ function addStoryTimestamp() {
   if (window.turnstile) window.turnstile.reset();
   storySubmitBtn.disabled = false;
 }
+
+    async function handleSubmit(event) {
+      event.preventDefault();
+      submitMessage.textContent = '';
+      submitMessage.className = 'message';
+      turnstileWarning.classList.add('hidden');
+
+      if (updateRateLimitUI()) {
+        submitMessage.textContent = 'Rate limit reached. Please wait before submitting again.';
+        submitMessage.className = 'message error';
+        return;
+      }
 
       const token = getTurnstileToken();
       if (!token) {


### PR DESCRIPTION
### Motivation
- The page was crashing due to inconsistent route names (`#/voices` vs `#/community`), a duplicated `renderRoute` implementation, an undefined `ROUTES` reference, and a community story submit handler (`submitStory`) being declared inside another function so it could not be attached during `init()`.

### Description
- Normalized the Community route to `#/community` and updated the header nav link to `href="#/community"` to match the `page-community` section and route map entry.
- Replaced the erroneous `ROUTES` reference with the existing `routes` object in `getCurrentRoute()` so route resolution uses the correct variable (`routes`).
- Removed the duplicate `renderRoute()` and consolidated routing behavior into a single `renderRoute()` that toggles `page-community` and calls `loadApprovedStories()` when the hash is `#/community`.
- Pulled `submitStory` out of the inner scope and defined it at top level so `storyForm.addEventListener('submit', submitStory)` in `init()` works as expected.

### Testing
- Searched the codebase (`rg`) to verify old `#/voices`/`ROUTES` usages were updated and found the expected changes in `index.html`, which passed inspection.
- Ran `git diff --check` to validate there were no whitespace or diff issues and the check succeeded.
- Committed the change (`git commit`) and confirmed the working tree was updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf5481e10832f9e1e31960e2defca)