### PR TITLE
Clear non-US country filter when selecting a US state

### DIFF
--- a/index.html
+++ b/index.html
@@ -1059,6 +1059,17 @@ function filterReportsByState(stateFullName) {
   if (searchInput) {
     searchInput.value = stateFullName;
   }
+
+  const selectedCountry = String((browseCountrySelect && browseCountrySelect.value) || '').trim();
+  if (selectedCountry && !isUnitedStatesCountryValue(selectedCountry)) {
+    setCountryDropdownValue('');
+    if (typeof window.clearSelectedWorldCountry === 'function') {
+      window.clearSelectedWorldCountry();
+    }
+  }
+
+  updateBrowseLocationFiltersUI();
+
   // Reuse your existing search filter
   if (typeof applySearchFilter === 'function') {
     applySearchFilter();


### PR DESCRIPTION
### Motivation
- Prevent a confusing mixed-filter state where a user selects a US state while a non‑US country is still selected (e.g., an African country + Texas) which can hide valid results; no skills were used for this small UI fix.

### Description
- Modify `filterReportsByState` in `index.html` to check the current `browseCountrySelect` value and, if it is set to a non‑US country (using existing `isUnitedStatesCountryValue`), clear the country dropdown, call `clearSelectedWorldCountry()` when available, and refresh the location filter UI before applying the search filter.

### Testing
- Ran `git diff --check` to ensure no whitespace/format issues and it passed. 
- Verified the change was staged and committed successfully (commit message: "Clear non-US country filter when selecting a US state").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecf99578f4832fbb09f1dc909bdf20)