### PR TITLE
Add Community tab to About page navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -220,6 +220,7 @@
       <nav>
         <a href="index.html#/browse" class="nav-link">Browse</a>
         <a href="index.html#/submit" class="nav-link">Submit</a>
+        <a href="index.html#/community" class="nav-link">Community</a>
         <a href="about.html" class="nav-link active">About</a>
       </nav>
     </div>


### PR DESCRIPTION
### Motivation
- Ensure the About page header matches other pages by exposing the Community route in the top navigation so users can reach the community page from About.

### Description
- Inserted a `Community` navigation link `<a href="index.html#/community" class="nav-link">Community</a>` into the header nav of `about.html` so the About page nav aligns with `index.html`.

### Testing
- Ran `git diff --check` to verify there are no whitespace or formatting issues and the change is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecffca6e44832f99ab46781020122d)