### PR TITLE
Display report submission timestamp inside Name cell

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,6 +259,13 @@
       gap: 0.45rem;
       flex-wrap: wrap;
     }
+
+    .report-timestamp {
+      font-size: 0.7rem;
+      color: var(--muted);
+      margin-top: 0.3rem;
+      display: block;
+    }
     .toast {
       position: fixed;
       right: 1rem;
@@ -1340,6 +1347,28 @@ function addStoryTimestamp() {
       reportCount.textContent = total + ' reports and counting...';
     }
 
+    function formatTimestamp(timestamp) {
+      if (!timestamp) {
+        return '';
+      }
+
+      const date = new Date(timestamp);
+      if (Number.isNaN(date.getTime())) {
+        return '';
+      }
+
+      return date.toLocaleString('en-US', {
+        timeZone: 'America/Los_Angeles',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        hour12: true,
+        timeZoneName: 'short'
+      });
+    }
+
     function renderStateField() {
       const selectedCountry = (countryField.value || '').trim();
 
@@ -1374,29 +1403,34 @@ function addStoryTimestamp() {
       }
 
       reports.forEach((report) => {
-  const categories = Array.isArray(report.categories) ? report.categories : [];
-  const pillHTML = categories
-    .map((category) => {
-      const normalized = String(category || '').toLowerCase().trim();
-      const cssClass = getCategoryClass(normalized);
-      return '<span class="pill ' + cssClass + '">' + escapeHTML(toTitleCase(normalized)) + '</span>';
-    })
-    .join('');
+        const categories = Array.isArray(report.categories) ? report.categories : [];
+        const pillHTML = categories
+          .map((category) => {
+            const normalized = String(category || '').toLowerCase().trim();
+            const cssClass = getCategoryClass(normalized);
+            return '<span class="pill ' + cssClass + '">' + escapeHTML(toTitleCase(normalized)) + '</span>';
+          })
+          .join('');
 
-  const row = document.createElement('tr');
-  row.innerHTML = `
-    <td data-label="Name">${escapeHTML(report.name || '')}</td>
-    <td data-label="Location">${formatLocation(report.city, report.state, report.country)}</td>
-    <td data-label="Categories"><div class="pills">${pillHTML}</div></td>
-    <td data-label="Actions">
-      <div class="row-actions">
-        <button type="button" class="report-entry-btn" data-report-id="${escapeHTML(report.id || '')}">Report this entry</button>
-        <button type="button" class="report-share-btn" data-report-id="${escapeHTML(report.id || '')}">Share</button>
-      </div>
-    </td>
-  `;
-  reportsBody.appendChild(row);
-});
+        const formattedTimestamp = formatTimestamp(report.created_at);
+        const timestampHTML = formattedTimestamp
+          ? '<span class="report-timestamp">' + escapeHTML(formattedTimestamp) + '</span>'
+          : '';
+
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td data-label="Name">${escapeHTML(report.name || '')}${timestampHTML}</td>
+          <td data-label="Location">${formatLocation(report.city, report.state, report.country)}</td>
+          <td data-label="Categories"><div class="pills">${pillHTML}</div></td>
+          <td data-label="Actions">
+            <div class="row-actions">
+              <button type="button" class="report-entry-btn" data-report-id="${escapeHTML(report.id || '')}">Report this entry</button>
+              <button type="button" class="report-share-btn" data-report-id="${escapeHTML(report.id || '')}">Share</button>
+            </div>
+          </td>
+        `;
+        reportsBody.appendChild(row);
+      });
     }
 
     function renderPagination(totalReports, page) {


### PR DESCRIPTION
### Motivation
- Show each report's submission time next to the name without adding a new table column. 
- Render the timestamp in Pacific Time with a short timezone abbreviation (e.g., "PDT"/"PST") using `toLocaleString`. 
- Place the timestamp directly under the name inside the existing Name `<td>` as a block-level, muted, smaller element. 
- Preserve the table header, mobile behavior, and the existing empty-state `colspan="4"`.

### Description
- Added a `formatTimestamp(timestamp)` helper that returns an `en-US` localized string using `timeZone: 'America/Los_Angeles'` and `timeZoneName: 'short'`. 
- Updated `renderReportRows(reports)` to call `formatTimestamp(report.created_at)` and, when present, append a `<span class="report-timestamp">...</span>` immediately after the escaped name inside the existing Name `<td>`. 
- Introduced `.report-timestamp` CSS rules (`font-size: 0.7rem; color: var(--muted); margin-top: 0.3rem; display: block;`) to make the timestamp small, muted, and block-level. 
- Did not change the table header text or the empty-state `colspan` value.

### Testing
- Ran `git diff --check` to verify no whitespace/formatting issues and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed518dfbc4832fbe15c647ab0737a7)