### PR TITLE
Fix report timestamps to reliably display California local time

### DIFF
--- a/index.html
+++ b/index.html
@@ -1352,7 +1352,17 @@ function addStoryTimestamp() {
         return '';
       }
 
-      const date = new Date(timestamp);
+      const timestampValue = String(timestamp).trim();
+      if (!timestampValue) {
+        return '';
+      }
+
+      const hasTimezoneInfo = /([zZ]|[+-]\d{2}:?\d{2})$/.test(timestampValue);
+      const normalizedTimestamp = hasTimezoneInfo
+        ? timestampValue
+        : timestampValue.replace(' ', 'T') + 'Z';
+
+      const date = new Date(normalizedTimestamp);
       if (Number.isNaN(date.getTime())) {
         return '';
       }


### PR DESCRIPTION
### Motivation
- Report timestamps submitted without explicit timezone information were being parsed as the browser's local time, producing a multi-hour offset when displayed for Pacific time users.  
- The UI should consistently render report `created_at` values in the site's intended California timezone (`America/Los_Angeles`).

### Description
- Updated `formatTimestamp` in `index.html` to normalize incoming timestamp strings before parsing.  
- The function now coerces the value to a trimmed string and detects timezone info with a regex (`/([zZ]|[+-]\d{2}:?\d{2})$/`).  
- If no timezone is present the code appends `Z` (treating the value as UTC), then constructs a `Date` from the normalized string and formats it with `toLocaleString` using `timeZone: 'America/Los_Angeles'` to preserve the existing display format.  

### Testing
- Ran a Node.js sanity check using `formatTimestamp('2026-04-25 23:43:00')` and `formatTimestamp('2026-04-25T23:43:00+00:00')` which both rendered as `Apr 25, 2026, 4:43 PM PDT`, and the check passed.  
- No other automated tests were modified or executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed52cdbf38832f8089602d8f561682)