### PR TITLE
Preserve browse pagination during live report refreshes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1218,7 +1218,8 @@ function filterReportsByState(stateFullName) {
       setBrowseTitleForSingleReport(null);
     }
 
-    function updateBrowseViewFromRoute() {
+    function updateBrowseViewFromRoute(options = {}) {
+      const preserveBrowsePage = Boolean(options.preserveBrowsePage);
       const route = getCurrentRoute();
       if (route !== '#/browse') {
         activeSingleReportId = null;
@@ -1232,7 +1233,7 @@ function filterReportsByState(stateFullName) {
         activeSingleReportId = null;
         setSingleReportControlsVisible(false);
         setBrowseTitleForSingleReport(null);
-        applySearchFilter();
+        applySearchFilter({ preservePage: preserveBrowsePage });
         return;
       }
 
@@ -1474,7 +1475,8 @@ function addStoryTimestamp() {
       renderPagination(reports.length, currentPage);
     }
 
-    function applySearchFilter() {
+    function applySearchFilter(options = {}) {
+      const preservePage = Boolean(options.preservePage);
       const reportId = getReportIdFromUrl();
       if (getCurrentRoute() === '#/browse' && reportId) {
         const matched = allReports.find((report) => String(report.id) === reportId);
@@ -1505,7 +1507,7 @@ function addStoryTimestamp() {
       });
 
       if (!query && !selectedCountry && !selectedState) {
-        renderPagedReports(filtered, 1);
+        renderPagedReports(filtered, preservePage ? currentPage : 1);
         browseMessage.textContent = filtered.length
           ? 'Loaded ' + allReports.length + ' report(s). Showing up to ' + REPORTS_PER_PAGE + ' per page.'
           : 'No reports yet. Be the first to submit.';
@@ -1513,7 +1515,7 @@ function addStoryTimestamp() {
         return;
       }
 
-      renderPagedReports(filtered, 1);
+      renderPagedReports(filtered, preservePage ? currentPage : 1);
       browseMessage.textContent = filtered.length
         ? 'Showing ' + filtered.length + ' of ' + allReports.length + ' report(s), ' + REPORTS_PER_PAGE + ' per page.'
         : 'No matching reports found.';
@@ -1541,7 +1543,7 @@ function addStoryTimestamp() {
     window.allReports = allReports;
     hasLoadedReports = true;
     updateReportCount(allReports.length);
-    updateBrowseViewFromRoute();
+    updateBrowseViewFromRoute({ preserveBrowsePage: true });
     browseMessage.textContent = allReports.length
       ? `Loaded ${allReports.length} report(s).`
       : 'No reports yet. Be the first to submit.';


### PR DESCRIPTION
### Motivation
- Users navigating to pages beyond the first were unexpectedly snapped back to page 1 whenever the background report refresh loaded new entries, disrupting browsing continuity.
- The intent is to allow periodic data reloads to refresh report data without forcing the UI back to the first pagination page.

### Description
- Add an `options` parameter to `updateBrowseViewFromRoute` and wire a `preserveBrowsePage` flag so route-driven view updates can opt into keeping the current page.
- Add an `options` parameter to `applySearchFilter` and support a `preservePage` mode so reapplying filters does not force pagination to page 1 when preservation is requested.
- Update `loadReports()` to call `updateBrowseViewFromRoute({ preserveBrowsePage: true })` after reloading data so automatic refreshes preserve the user's current page where appropriate.
- Adjust internal calls so the `preservePage` option is passed through when route handling decides not to show a single shared report.

### Testing
- No automated tests exist in this repository, so no automated test runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed549a8cd4832fa2a07477aabf6ab0)