### PR TITLE
Show community post submission time in Pacific Daylight Time (PDT)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1380,6 +1380,17 @@ function addStoryTimestamp() {
       });
     }
 
+    function formatCommunityPostTimestamp(timestamp) {
+      const formattedTimestamp = formatTimestamp(timestamp);
+      if (!formattedTimestamp) {
+        return 'Unknown date/time (PDT)';
+      }
+
+      return formattedTimestamp.includes('PDT')
+        ? formattedTimestamp
+        : `${formattedTimestamp} PDT`;
+    }
+
     function hasNumber(value) {
       return /\d/.test(String(value || ''));
     }
@@ -1610,13 +1621,13 @@ function addStoryTimestamp() {
 
   let html = '';
   for (const story of data) {
-    const date = new Date(story.created_at).toLocaleDateString();
+    const submittedAt = formatCommunityPostTimestamp(story.created_at);
     const titleHtml = story.title ? `<h4>${escapeHTML(story.title)}</h4>` : '';
     html += `
       <div class="story-card">
         ${titleHtml}
         <p>${escapeHTML(story.content)}</p>
-        <div class="story-meta">— Anonymous, ${date}</div>
+        <div class="story-meta">— Anonymous, ${submittedAt}</div>
       </div>
     `;
   }


### PR DESCRIPTION
### Motivation
- Community posts currently showed only a date; the UI should display the full submission date and time in Pacific Time with an explicit PDT suffix when appropriate.

### Description
- Added `formatCommunityPostTimestamp()` which reuses `formatTimestamp()` to format a timestamp in the `America/Los_Angeles` zone and appends a `PDT` suffix as a fallback, and updated the community stories renderer to show `submittedAt` (date + time) in the story meta line in `index.html`.

### Testing
- No automated test suite is present; verified the change by inspecting `index.html` with `rg -n "formatCommunityPostTimestamp|story-meta|formatTimestamp\(" index.html` and viewing the modified regions with `nl -ba index.html | sed -n '1348,1398p'` and `nl -ba index.html | sed -n '1616,1635p'`, all confirming the new helper and usage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed68da5168832faef76d620dc70766)