### PR TITLE
Collapse Community "Submit post" form behind a button

### DIFF
--- a/index.html
+++ b/index.html
@@ -816,8 +816,9 @@
       <section id="page-community" class="page">
   <h2>Community Voices</h2>
   <p>Share your story or just a few words anonymously, without names. This is a space for hope, encouragement, and survivor experiences. No names of abusers or yourself. Your post will be reviewed before appearing.</p>
+  <button id="show-story-form-btn" type="button" aria-expanded="false" aria-controls="story-form">Submit post</button>
   
-  <form id="story-form" class="panel" style="max-width: 720px;">
+  <form id="story-form" class="panel hidden" style="max-width: 720px;">
     <div class="row">
       <label for="story-title">Title (optional)</label>
       <input id="story-title" type="text" maxlength="100" placeholder="e.g., A message of hope" />
@@ -907,6 +908,7 @@
     const REPORTS_PER_PAGE = 100;
     const DEFAULT_PAGE_TITLE = document.title || 'NameHim';
     const storyForm = document.getElementById('story-form');
+    const showStoryFormBtn = document.getElementById('show-story-form-btn');
     const storyTitle = document.getElementById('story-title');
     const storyContent = document.getElementById('story-content');
     const storySubmitBtn = document.getElementById('submit-story-btn');
@@ -1651,6 +1653,15 @@ function addStoryTimestamp() {
         .map((input) => input.value);
     }
 
+    function openStoryForm() {
+      if (!storyForm || !showStoryFormBtn) {
+        return;
+      }
+      storyForm.classList.remove('hidden');
+      showStoryFormBtn.classList.add('hidden');
+      showStoryFormBtn.setAttribute('aria-expanded', 'true');
+    }
+
     async function submitStory(event) {
   event.preventDefault();
   storyMessage.textContent = '';
@@ -1990,6 +2001,9 @@ function addStoryTimestamp() {
       });
       reportForm.addEventListener('submit', handleSubmit);
       storyForm.addEventListener('submit', submitStory);
+      if (showStoryFormBtn) {
+        showStoryFormBtn.addEventListener('click', openStoryForm);
+      }
     }
 
    // --- World Map Toggle (similar to US Map) ---


### PR DESCRIPTION
### Motivation
- Prevent the community story form from being visible by default so users must intentionally open it after reading the guidance text, reducing accidental submissions and aligning with the UX request to place a small "Submit post" button under the Community guidance copy.

### Description
- Added a `Submit post` button under the Community guidance paragraph (`<button id="show-story-form-btn" ...>`). 
- Hid the story form on load by adding the `hidden` class to `#story-form` in the markup. 
- Added `showStoryFormBtn` wiring and an `openStoryForm()` function that removes the `hidden` class from the form, hides the button, and updates `aria-expanded` for accessibility. 
- Registered a click handler for the button during initialization so the form is revealed when the user clicks it.

### Testing
- Ran `git diff --check` to validate there were no whitespace/style issues, which passed. 
- Ran `git status --short` to confirm the working tree changes, which showed the intended modified file(s).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed79dd37b0832f960ee625e4e4260f)