### PR TITLE
Format report totals with thousands separators

### DIFF
--- a/about.html
+++ b/about.html
@@ -291,6 +291,11 @@
   </footer>
 
   <script>
+    function formatReportTotal(total) {
+      const parsedTotal = Number(total) || 0;
+      return parsedTotal.toLocaleString('en-US');
+    }
+
     async function loadReportCount() {
       const reportCount = document.getElementById('report-count');
       if (!reportCount) {
@@ -310,7 +315,7 @@
           throw new Error('Worker did not return an array');
         }
 
-        reportCount.textContent = reports.length + ' reports and counting...';
+        reportCount.textContent = formatReportTotal(reports.length) + ' reports and counting...';
       } catch (error) {
         console.error('Failed to load report count:', error);
         reportCount.textContent = '0 reports and counting...';

--- a/index.html
+++ b/index.html
@@ -1346,8 +1346,13 @@ function addStoryTimestamp() {
       return parts.join(', ');
     }
 
+    function formatReportTotal(total) {
+      const parsedTotal = Number(total) || 0;
+      return parsedTotal.toLocaleString('en-US');
+    }
+
     function updateReportCount(total) {
-      reportCount.textContent = total + ' reports and counting...';
+      reportCount.textContent = formatReportTotal(total) + ' reports and counting...';
     }
 
     function formatTimestamp(timestamp) {


### PR DESCRIPTION
### Motivation
- The header report counter stopped displaying readable values after 999, so totals should be rendered with thousands separators (e.g. `1,000`, `12,345`, `1,000,000`) so the counter remains human-readable as it grows.

### Description
- Added a small helper `formatReportTotal` that uses `toLocaleString('en-US')` and applied it to the report count rendering in `index.html` (`updateReportCount`) and `about.html` (`loadReportCount`) so both pages display formatted totals.

### Testing
- Ran automated checks to confirm the new helper and usages are present with `rg -n "formatReportTotal|updateReportCount\(|reports and counting" index.html about.html` and inspected the updated lines with `nl`/`sed`; the checks located the new function and its uses and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7a6f0868832fa03c1761f2770984)