### PR TITLE
Fix report loading beyond 999 entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -1523,6 +1523,36 @@ function addStoryTimestamp() {
       renderPagination(reports.length, currentPage);
     }
 
+
+    async function fetchAllReportsFromSupabase(batchSize = 1000) {
+      const collected = [];
+      let from = 0;
+
+      while (true) {
+        const to = from + batchSize - 1;
+        const { data, error } = await supabaseClient
+          .from('reports')
+          .select('*')
+          .order('created_at', { ascending: false })
+          .range(from, to);
+
+        if (error) {
+          throw error;
+        }
+
+        const rows = Array.isArray(data) ? data : [];
+        collected.push(...rows);
+
+        if (rows.length < batchSize) {
+          break;
+        }
+
+        from += batchSize;
+      }
+
+      return collected;
+    }
+
     function applySearchFilter(options = {}) {
       const preservePage = Boolean(options.preservePage);
       const reportId = getReportIdFromUrl();
@@ -1587,7 +1617,25 @@ function addStoryTimestamp() {
       throw new Error('Worker did not return an array');
     }
 
-    allReports = reports;
+    let resolvedReports = reports;
+
+    try {
+      const { count, error: countError } = await supabaseClient
+        .from('reports')
+        .select('*', { count: 'exact', head: true });
+
+      if (countError) {
+        throw countError;
+      }
+
+      if ((Number(count) || 0) > reports.length) {
+        resolvedReports = await fetchAllReportsFromSupabase();
+      }
+    } catch (fallbackError) {
+      console.warn('Unable to compare/fallback report source, continuing with worker data:', fallbackError);
+    }
+
+    allReports = resolvedReports;
     window.allReports = allReports;
     hasLoadedReports = true;
     updateReportCount(allReports.length);


### PR DESCRIPTION
### Motivation
- Users reported that reports near the end disappear once the dataset passes ~999 entries, indicating the Browse view can be silently truncated when the worker payload is capped. 
- The intent is to detect capped worker responses and recover full rows directly from Supabase so the UI shows all reports.

### Description
- Added a new helper `fetchAllReportsFromSupabase(batchSize = 1000)` that pages through the `reports` table with `.range(from, to)` and collects all rows in batches.  
- Updated `loadReports()` to still fetch the worker payload first, then query Supabase with `select('*', { count: 'exact', head: true })` and, when the table `count` is larger than the worker response, fall back to `fetchAllReportsFromSupabase()` and use that full dataset.  
- Preserved resilient behavior by catching errors during the count/fallback check and continuing to use the worker data if Supabase access fails, while logging a warning.

### Testing
- Ran a JavaScript syntax check with `node --check` against the extracted inline app script which succeeded.  
- Performed repository and file checks (`git status` and `git commit`) to validate the change was applied, and the commit completed successfully.  
- Earlier automated extraction attempts failed due to partial script selection, but the final extraction and `node --check` validation succeeded and no runtime syntax errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed7c6b28b4832f87c7ce43f5fbfae1)