### PR TITLE
Improve browse pagination with compact modern controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -307,6 +307,12 @@
       font-weight: 700;
     }
 
+    .pagination-ellipsis {
+      color: var(--muted);
+      padding: 0 0.2rem;
+      user-select: none;
+    }
+
     .panel {
       background: var(--panel);
       border: 1px solid var(--border);
@@ -1495,21 +1501,55 @@ function addStoryTimestamp() {
     function renderPagination(totalReports, page) {
       browsePagination.innerHTML = '';
       const totalPages = Math.ceil(totalReports / REPORTS_PER_PAGE);
+      const maxVisiblePageButtons = 5;
 
       if (totalPages <= 1) {
         return;
       }
 
-      const previousDisabled = page <= 1 ? ' disabled' : '';
-      const nextDisabled = page >= totalPages ? ' disabled' : '';
-      let paginationHTML = '<button type="button" data-page-nav="prev"' + previousDisabled + '>Previous</button>';
+      const isAtFirstPage = page <= 1;
+      const isAtLastPage = page >= totalPages;
+      let paginationHTML = '';
 
-      for (let pageNumber = 1; pageNumber <= totalPages; pageNumber += 1) {
-        const activeClass = pageNumber === page ? ' class="active"' : '';
-        paginationHTML += '<button type="button" data-page="' + pageNumber + '"' + activeClass + '>' + pageNumber + '</button>';
+      paginationHTML += '<button type="button" data-page-nav="first"' + (isAtFirstPage ? ' disabled' : '') + '>First</button>';
+      paginationHTML += '<button type="button" data-page-nav="prev"' + (isAtFirstPage ? ' disabled' : '') + '>Previous</button>';
+
+      let startPage = 1;
+      let endPage = totalPages;
+
+      if (totalPages > maxVisiblePageButtons) {
+        const halfWindow = Math.floor(maxVisiblePageButtons / 2);
+        startPage = Math.max(1, page - halfWindow);
+        endPage = startPage + maxVisiblePageButtons - 1;
+
+        if (endPage > totalPages) {
+          endPage = totalPages;
+          startPage = endPage - maxVisiblePageButtons + 1;
+        }
       }
 
-      paginationHTML += '<button type="button" data-page-nav="next"' + nextDisabled + '>Next</button>';
+      if (startPage > 1) {
+        paginationHTML += '<button type="button" data-page="1">1</button>';
+        if (startPage > 2) {
+          paginationHTML += '<span class="pagination-ellipsis" aria-hidden="true">…</span>';
+        }
+      }
+
+      for (let pageNumber = startPage; pageNumber <= endPage; pageNumber += 1) {
+        const activeClass = pageNumber === page ? ' class="active"' : '';
+        const currentPageAttr = pageNumber === page ? ' aria-current="page"' : '';
+        paginationHTML += '<button type="button" data-page="' + pageNumber + '"' + activeClass + currentPageAttr + '>' + pageNumber + '</button>';
+      }
+
+      if (endPage < totalPages) {
+        if (endPage < totalPages - 1) {
+          paginationHTML += '<span class="pagination-ellipsis" aria-hidden="true">…</span>';
+        }
+        paginationHTML += '<button type="button" data-page="' + totalPages + '">' + totalPages + '</button>';
+      }
+
+      paginationHTML += '<button type="button" data-page-nav="next"' + (isAtLastPage ? ' disabled' : '') + '>Next</button>';
+      paginationHTML += '<button type="button" data-page-nav="last"' + (isAtLastPage ? ' disabled' : '') + '>Last</button>';
       browsePagination.innerHTML = paginationHTML;
     }
 
@@ -2050,6 +2090,11 @@ function addStoryTimestamp() {
           renderPagedReports(currentFilteredReports, currentPage - 1);
         } else if (navDirection === 'next') {
           renderPagedReports(currentFilteredReports, currentPage + 1);
+        } else if (navDirection === 'first') {
+          renderPagedReports(currentFilteredReports, 1);
+        } else if (navDirection === 'last') {
+          const totalPages = Math.max(1, Math.ceil(currentFilteredReports.length / REPORTS_PER_PAGE));
+          renderPagedReports(currentFilteredReports, totalPages);
         }
       });
       reportForm.addEventListener('submit', handleSubmit);


### PR DESCRIPTION
### Motivation
- The existing pagination rendered a button for every page which produced very long, unwieldy controls on large result sets. 
- Implement a more modern, stable UX that shows a small sliding window of page buttons with ellipses and explicit first/last navigation.

### Description
- Replace full-page-number rendering with a sliding window limited to `maxVisiblePageButtons = 5` and compute `startPage`/`endPage` to center the window around the current page.  
- Add `First` and `Last` navigation buttons and preserve `Previous`/`Next` behavior with appropriate disabled states at the ends.  
- Render leading/trailing ellipses (`.pagination-ellipsis`) and always expose page `1` and the final page when ranges are truncated, and add `aria-current="page"` to the active page button for accessibility.  
- Extend the pagination click handler to support `data-page-nav="first"` and `data-page-nav="last"`, and add a small CSS rule for the ellipsis styling.

### Testing
- Ran `git diff --check` to ensure there were no whitespace or diff errors and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edadfe51c4832f84f084b34c7dbb8f)