### PR TITLE
Animate loading dots for header report count on index/about

### DIFF
--- a/about.html
+++ b/about.html
@@ -310,6 +310,32 @@
       return parsedTotal.toLocaleString('en-US');
     }
 
+    const loadingDots = ['.', '..', '...'];
+    let loadingDotIndex = 0;
+    let reportCountLoadingInterval = null;
+
+    function startReportCountLoadingAnimation(reportCount) {
+      if (!reportCount || reportCountLoadingInterval) {
+        return;
+      }
+
+      reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      reportCountLoadingInterval = setInterval(() => {
+        loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
+        reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      }, 1000);
+    }
+
+    function stopReportCountLoadingAnimation() {
+      if (!reportCountLoadingInterval) {
+        return;
+      }
+
+      clearInterval(reportCountLoadingInterval);
+      reportCountLoadingInterval = null;
+      loadingDotIndex = 0;
+    }
+
     const SUPABASE_URL = 'https://cmmggaprguusffiphegy.supabase.co';
     const SUPABASE_ANON_KEY = 'sb_publishable_G9Doh6gciyFVT1NDum55ZA_8ryL3fOw';
     const supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
@@ -319,6 +345,7 @@
       if (!reportCount) {
         return;
       }
+      startReportCountLoadingAnimation(reportCount);
 
       const WORKER_URL = 'https://api.namehim.app/filtered-reports';
 
@@ -353,6 +380,8 @@
       } catch (error) {
         console.error('Failed to load report count:', error);
         reportCount.textContent = '0 reports and counting...';
+      } finally {
+        stopReportCountLoadingAnimation();
       }
     }
 

--- a/index.html
+++ b/index.html
@@ -1361,6 +1361,32 @@ function addStoryTimestamp() {
       reportCount.textContent = formatReportTotal(total) + ' reports and counting...';
     }
 
+    const loadingDots = ['.', '..', '...'];
+    let loadingDotIndex = 0;
+    let reportCountLoadingInterval = null;
+
+    function startReportCountLoadingAnimation() {
+      if (!reportCount || reportCountLoadingInterval) {
+        return;
+      }
+
+      reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      reportCountLoadingInterval = setInterval(() => {
+        loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
+        reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      }, 1000);
+    }
+
+    function stopReportCountLoadingAnimation() {
+      if (!reportCountLoadingInterval) {
+        return;
+      }
+
+      clearInterval(reportCountLoadingInterval);
+      reportCountLoadingInterval = null;
+      loadingDotIndex = 0;
+    }
+
     function formatTimestamp(timestamp) {
       if (!timestamp) {
         return '';
@@ -1641,6 +1667,7 @@ function addStoryTimestamp() {
     }
 
     async function loadReports() {
+  startReportCountLoadingAnimation();
   browseMessage.textContent = 'Loading reports...';
   browseMessage.className = 'message';
 
@@ -1678,6 +1705,7 @@ function addStoryTimestamp() {
     allReports = resolvedReports;
     window.allReports = allReports;
     hasLoadedReports = true;
+    stopReportCountLoadingAnimation();
     updateReportCount(allReports.length);
     updateBrowseViewFromRoute({ preserveBrowsePage: true });
     browseMessage.textContent = allReports.length
@@ -1691,6 +1719,7 @@ function addStoryTimestamp() {
     allReports = [];
     window.allReports = allReports;
     hasLoadedReports = true;
+    stopReportCountLoadingAnimation();
     updateReportCount(0);
     renderPagedReports([], 1);
   }


### PR DESCRIPTION
### Motivation
- Improve header UX by showing an animated "loading" ellipsis while report totals are being fetched so the header indicates active progress.
- Ensure both the main browse header and the about page header behave consistently while loading and restore the numeric summary once data is available or fails.

### Description
- Added a small loading-dot utility (`loadingDots`, `startReportCountLoadingAnimation`, `stopReportCountLoadingAnimation`) that cycles `.` → `..` → `...` once per second and updates the header text while loading.
- Wired the animation into the browse flow by calling `startReportCountLoadingAnimation()` at the start of `loadReports()` and `stopReportCountLoadingAnimation()` on both success and error paths, then updating the header with `updateReportCount()` as before.
- Mirrored the same animation in `about.html` by starting the animation at the beginning of `loadReportCount()` and stopping it in the `finally` block after the fetch completes or fails.

### Testing
- Ran `git diff --check` and `git status --short` which produced no issues and showed the two modified files (`index.html` and `about.html`).
- Committed the changes successfully with `git commit -m "Animate loading dots in report-count headers"`.
- No automated unit tests were present for UI behavior in this repository; front-end rendering was not executed in this environment (no browser automation ran).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee802bb08c832fa6a7dc30ca693648)