### PR TITLE
Add financial transparency + optional support section to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -289,6 +289,15 @@
           <h3>Why this exists</h3>
           <p>The original site (that someone else made) went down within days. People still need a space to share concerns anonymously, responsibly, without fear. This is my attempt to keep that door open. I'll improve it over time. Suggestions are welcome.</p>
         </section>
+
+        <section>
+          <h3>Financial Transparency and Optional Support</h3>
+          <p>Hello, I built this open source project as a single developer and have so far spent about $40 on hosting and maintaining the site and database it displays. I'm not sure what other costs might arise, but I've already put many hours into developing and maintaining it and am willing to continue doing that. My fiance is 9 months pregnant and we are already using credit to maintain our bills and our rental. Beyond that, the transmission for our car just went out.</p>
+          <p>I am committed to keeping this site up, functional, and free. If you want to support that by helping with the costs of the site, or if there's any extra to help me and my family with our bills or other necessities so we can bring our child into a stable environment, it is greatly appreciated.</p>
+          <p>(When things develop, such as the arrival of our baby or when we get into a more stable position, I will update this section to let you guys know.)</p>
+          <script src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
+          <script>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'R5R81YISDW');kofiwidget2.draw();</script>
+        </section>
       </article>
     </div>
   </main>


### PR DESCRIPTION
### Motivation
- Add a `Financial Transparency and Optional Support` section to the About page so the project maintainer can disclose personal expenses and provide an optional way for visitors to donate via Ko-fi.

### Description
- Inserted a new `<section>` at the end of `about.html` containing an `<h3>` heading, three paragraphs with the supplied transparency/support text, and the embedded Ko-fi widget scripts (`https://storage.ko-fi.com/cdn/widget/Widget_2.js` and `kofiwidget2.init(...)`).

### Testing
- Ran `git diff --check` which produced no issues and committed the updated `about.html` successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec30a1548832f85585fb7def33fce)