### PR TITLE
Center Ko‑Fi and PayPal support buttons on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -173,6 +173,15 @@
       color: #bfdbfe;
     }
 
+    .support-buttons {
+      margin-top: 0.9rem;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      gap: 0.7rem;
+      flex-wrap: wrap;
+    }
+
     footer {
       border-top: 1px solid var(--border);
       background: rgba(17, 24, 39, 0.85);
@@ -295,15 +304,20 @@
           <p>Hello, I built this open source project as a single developer and have so far spent about $40 on hosting and maintaining the site and database it displays. I'm not sure what other costs might arise, but I've already put many hours into developing and maintaining it and am willing to continue doing that. My fiance is 9 months pregnant and we are already using credit to maintain our bills and our rental. Beyond that, the transmission for our car just went out.</p>
           <p>I am committed to keeping this site up, functional, and free. If you want to support that by helping with the costs of the site, or if there's any extra to help me and my family with our bills or other necessities so we can bring our child into a stable environment, it is greatly appreciated.</p>
           <p>(When things develop, such as the arrival of our baby or when we get into a more stable position, I will update this section to let you guys know.)</p>
-          <script src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
-          <script>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'R5R81YISDW');kofiwidget2.draw();</script> <div>
-  <style>.pp-Y88TMRL6PM2EQ{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
-  <form action="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
-    <input class="pp-Y88TMRL6PM2EQ" type="submit" value="Support via Paypal" />
-    <img src=https://www.paypalobjects.com/images/Debit_Credit_APM.svg alt="cards" />
-    <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
-  </form>
-</div>
+          <div class="support-buttons">
+            <div>
+              <script src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
+              <script>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'R5R81YISDW');kofiwidget2.draw();</script>
+            </div>
+            <div>
+              <style>.pp-Y88TMRL6PM2EQ{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
+              <form action="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">
+                <input class="pp-Y88TMRL6PM2EQ" type="submit" value="Support via Paypal" />
+                <img src=https://www.paypalobjects.com/images/Debit_Credit_APM.svg alt="cards" />
+                <section style="font-size: 0.75rem;"> Powered by <img src="https://www.paypalobjects.com/paypal-ui/logos/svg/paypal-wordmark-color.svg" alt="paypal" style="height:0.875rem;vertical-align:middle;"/></section>
+              </form>
+            </div>
+          </div>
         </section>
       </article>
     </div>


### PR DESCRIPTION
### Motivation
- Prevent the Ko‑Fi and PayPal controls from touching and center them on the About page for a cleaner, more readable layout.

### Description
- Added a `.support-buttons` flex container in `about.html` and wrapped the Ko‑Fi widget and PayPal form so they render on a single centered row with a small `gap` and `flex-wrap` for narrow screens.

### Testing
- No automated tests were run because this is a static HTML/CSS change; the updated `about.html` was applied and committed and `git status` confirmed a clean working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eec8d2b564832fa13d7456400927c5)