### PR TITLE
Fix report counter and loading animation; paginate Supabase fetch to avoid 1,000-row cap

### DIFF
--- a/index.html
+++ b/index.html
@@ -1753,7 +1753,7 @@ function addStoryTimestamp() {
         const to = from + batchSize - 1;
         const { data, error } = await supabaseClient
           .from('reports')
-          .select('*')
+          .select('id,name,city,state,country,categories,created_at')
           .order('created_at', { ascending: false })
           .range(from, to);
 
@@ -1824,19 +1824,12 @@ function addStoryTimestamp() {
     async function loadReports() {
   browseMessage.textContent = 'Loading reports...';
   browseMessage.className = 'message';
+  startReportCountLoadingAnimation();
 
   try {
-    // Direct Supabase query – no worker involved
-    const { data, error } = await supabaseClient
-      .from('reports')
-      .select('id,name,city,state,country,categories,created_at')
-      .order('created_at', { ascending: false });
+    const reports = await fetchAllReportsFromSupabase(1000);
 
-    if (error) {
-      throw error;
-    }
-
-    allReports = sanitizeFetchedReports(data || []);
+    allReports = sanitizeFetchedReports(reports || []);
     window.allReports = allReports;
     hasLoadedReports = true;
     updateReportCount(allReports.length);
@@ -1846,7 +1839,7 @@ function addStoryTimestamp() {
       : 'No reports yet. Be the first to submit.';
     browseMessage.className = 'message';
   } catch (error) {
-    console.error('Failed to load reports directly from Supabase:', error);
+    console.error('Failed to load reports from Supabase:', error);
     browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';
     browseMessage.className = 'message error';
     allReports = [];
@@ -1854,6 +1847,8 @@ function addStoryTimestamp() {
     hasLoadedReports = true;
     updateReportCount(0);
     renderPagedReports([], 1);
+  } finally {
+    stopReportCountLoadingAnimation();
   }
 }
 


### PR DESCRIPTION
### Motivation
- The live report headline stopped increasing past 1,000 because a direct Supabase `select(...)` returned only the default page of results, and the loading-dot animation stopped because its lifecycle wasn't started/stopped during the fetch.
- The goal is to restore accurate live totals for large datasets and bring back the loading indicator while reports are being loaded.

### Description
- Rewrote `loadReports()` to fetch all rows via the existing `fetchAllReportsFromSupabase(batchSize = 1000)` pagination helper instead of a single `select(...)` call, ensuring datasets >1,000 rows are completely loaded and counted. 
- Started the report-count animation by calling `startReportCountLoadingAnimation()` at the top of `loadReports()` and ensured it always stops in a `finally` block via `stopReportCountLoadingAnimation()`.
- Aligned the paginated fetch `select` columns to the browse payload by using `select('id,name,city,state,country,categories,created_at')` when paging.
- Minor error log message normalized to `'Failed to load reports from Supabase:'` and ensured `window.allReports` and UI state are updated consistently on success/failure.

### Testing
- Ran repository checks including `git diff --check` and `git status --short`, which succeeded after the change.
- Verified code edits with `rg`/line inspection to confirm `fetchAllReportsFromSupabase`, `startReportCountLoadingAnimation`, and `stopReportCountLoadingAnimation` are wired into `loadReports()`; those searches returned expected matches.
- Committed the change locally (`Fix report counter loading and Supabase pagination`).
- No automated browser/UI tests were available in this environment, so visual verification of the counter/loader was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eee7753fc8832f93dd56b8e4324677)