### PR TITLE
Temporary submission kill switch for report form

### DIFF
--- a/index.html
+++ b/index.html
@@ -2027,6 +2027,7 @@ function addStoryTimestamp() {
       submitMessage.textContent = '';
       submitMessage.className = 'message';
       turnstileWarning.classList.add('hidden');
+      if (true) return void (submitMessage.textContent = 'Submissions are temporarily disabled.');
 
       if (updateRateLimitUI()) {
         submitMessage.textContent = 'Rate limit reached. Please wait before submitting again.';


### PR DESCRIPTION
### Motivation
- Provide an immediate, reversible mitigation to stop spam by preventing the report form handler from proceeding so the site stops receiving new submissions.

### Description
- Add a single-line early return in `handleSubmit` inside `index.html` that sets `submitMessage.textContent = 'Submissions are temporarily disabled.'` and returns immediately, blocking all report submissions.

### Testing
- Ran `git diff --check` which produced no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef369b3d4832f96f6901ca76aa29e)