### PR TITLE
Restrict report form inputs to English letters (A-Z)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1565,7 +1565,7 @@ function addStoryTimestamp() {
       if (!normalized) {
         return false;
       }
-      return !/^[\p{L}\s]+$/u.test(normalized);
+      return !/^[A-Za-z\s]+$/.test(normalized);
     }
 
     function preventInvalidCharsForField(fieldElement) {
@@ -1576,7 +1576,7 @@ function addStoryTimestamp() {
       fieldElement.dataset.lettersOnlyBound = 'true';
       fieldElement.addEventListener('input', () => {
         const cleanedValue = fieldElement.value
-          .replace(/[^\p{L}\s]+/gu, '')
+          .replace(/[^A-Za-z\s]+/g, '')
           .replace(/\s+/g, ' ')
           .trimStart();
         if (cleanedValue !== fieldElement.value) {
@@ -2070,7 +2070,7 @@ function addStoryTimestamp() {
         hasInvalidLettersOnlyChars(payload.city) ||
         (shouldValidateStateInput && hasInvalidLettersOnlyChars(payload.state))
       ) {
-        submitMessage.textContent = '* Name and Location can only contain letters.';
+        submitMessage.textContent = '* Name and Location can only contain English letters (A-Z).';
         submitMessage.className = 'message error';
         return;
       }


### PR DESCRIPTION
### Motivation
- Prevent non-English scripts (e.g., Arabic) from being entered into the Name/City/State fields because they're breaking the form and causing display/validation issues.

### Description
- Updated client-side validation in `index.html` to only permit ASCII English letters and spaces by changing the validation pattern to `^[A-Za-z\s]+$` and the sanitization replace to `/[^A-Za-z\s]+/g`.
- Applied the restriction to the existing `hasInvalidLettersOnlyChars` check and the live input cleaning in `preventInvalidCharsForField`, which are bound to the `name`, `city`, and `state` inputs.
- Clarified the user-facing submit error message to explicitly say: `* Name and Location can only contain English letters (A-Z).`

### Testing
- Ran content checks with `rg -n "A-Za-z|English letters" index.html` to verify the new patterns and message are present, which succeeded.
- Confirmed the working tree state with `git status --short` and committed the changes, and the commit completed successfully.
- Patch application (`apply_patch`) succeeded and the modified `index.html` was updated without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eef958d45c832f848cf347a3160ef0)