### PR TITLE
Harden report input validation against direct DB abuse

### DIFF
--- a/index.html
+++ b/index.html
@@ -922,7 +922,6 @@
     const MAP_VISIBILITY_STORAGE_KEY = 'namehim_us_map_visible';
     const browsePagination = document.getElementById('browse-pagination');
     const REPORTS_PER_PAGE = 100;
-    const MAX_REPORT_FIELD_LENGTH = 80;
     const MAX_CATEGORY_LENGTH = 40;
     const MAX_CATEGORY_COUNT = 8;
     const MAX_CATEGORY_TOTAL_CHARS = 240;
@@ -999,6 +998,17 @@
       return normalized.slice(0, maxLength);
     }
 
+    function sanitizeLettersOnlyText(value, maxLength) {
+      const normalized = sanitizeReportText(value, maxLength);
+      if (!normalized) {
+        return '';
+      }
+      return normalized
+        .replace(/[^A-Za-z\s]+/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+    }
+
     function sanitizeCategoryList(rawCategories) {
       if (!Array.isArray(rawCategories)) {
         return [];
@@ -1060,10 +1070,10 @@
 
       return rows.map((report) => ({
         id: Number(report && report.id) || 0,
-        name: sanitizeReportText(report && report.name, MAX_REPORT_FIELD_LENGTH),
-        city: sanitizeReportText(report && report.city, MAX_REPORT_FIELD_LENGTH),
-        state: sanitizeReportText(report && report.state, MAX_REPORT_FIELD_LENGTH),
-        country: sanitizeReportText(report && report.country, MAX_REPORT_FIELD_LENGTH),
+        name: sanitizeLettersOnlyText(report && report.name, MAX_BROWSE_FIELD_LENGTH),
+        city: sanitizeLettersOnlyText(report && report.city, MAX_BROWSE_FIELD_LENGTH),
+        state: sanitizeLettersOnlyText(report && report.state, MAX_BROWSE_FIELD_LENGTH),
+        country: sanitizeLettersOnlyText(report && report.country, MAX_BROWSE_FIELD_LENGTH),
         categories: sanitizeCategoryList(report && report.categories),
         created_at: sanitizeReportText(report && report.created_at, 64),
       }));

--- a/supabase.sql
+++ b/supabase.sql
@@ -14,20 +14,32 @@ create table if not exists public.reports (
 -- Ensure core report fields cannot be blank and stay within expected lengths.
 alter table public.reports
   drop constraint if exists reports_name_check,
+  drop constraint if exists reports_name_letters_check,
   drop constraint if exists reports_city_check,
+  drop constraint if exists reports_city_letters_check,
   drop constraint if exists reports_state_check,
+  drop constraint if exists reports_state_letters_check,
   drop constraint if exists reports_country_check,
+  drop constraint if exists reports_country_letters_check,
   drop constraint if exists reports_submitter_uuid_check;
 
 alter table public.reports
   add constraint reports_name_check
-    check (char_length(btrim(name)) between 1 and 20),
+    check (char_length(btrim(name)) between 1 and 20 and octet_length(name) <= 80),
+  add constraint reports_name_letters_check
+    check (btrim(name) ~ '^[A-Za-z ]+$'),
   add constraint reports_city_check
-    check (char_length(btrim(city)) between 1 and 20),
+    check (char_length(btrim(city)) between 1 and 20 and octet_length(city) <= 80),
+  add constraint reports_city_letters_check
+    check (btrim(city) ~ '^[A-Za-z ]+$'),
   add constraint reports_state_check
-    check (state is null or char_length(btrim(state)) between 1 and 20),
+    check (state is null or (char_length(btrim(state)) between 1 and 20 and octet_length(state) <= 80)),
+  add constraint reports_state_letters_check
+    check (state is null or btrim(state) ~ '^[A-Za-z ]+$'),
   add constraint reports_country_check
-    check (char_length(btrim(country)) between 1 and 20),
+    check (char_length(btrim(country)) between 1 and 20 and octet_length(country) <= 80),
+  add constraint reports_country_letters_check
+    check (btrim(country) ~ '^[A-Za-z ]+$'),
   add constraint reports_submitter_uuid_check
     check (char_length(btrim(submitter_uuid)) between 16 and 100);
 
@@ -74,9 +86,17 @@ for insert
 to anon, authenticated
 with check (
   char_length(btrim(name)) between 1 and 20
+  and btrim(name) ~ '^[A-Za-z ]+$'
+  and octet_length(name) <= 80
   and char_length(btrim(city)) between 1 and 20
+  and btrim(city) ~ '^[A-Za-z ]+$'
+  and octet_length(city) <= 80
   and (state is null or char_length(btrim(state)) between 1 and 20)
+  and (state is null or btrim(state) ~ '^[A-Za-z ]+$')
+  and (state is null or octet_length(state) <= 80)
   and char_length(btrim(country)) between 1 and 20
+  and btrim(country) ~ '^[A-Za-z ]+$'
+  and octet_length(country) <= 80
   and char_length(btrim(submitter_uuid)) between 16 and 100
   and array_length(categories, 1) between 1 and 8
   and categories <@ array[


### PR DESCRIPTION
### Motivation
- Attackers were bypassing client-side checks by writing directly to Supabase with the public anon key, inserting non-English and oversized multibyte values that could crash the browse UI. 
- Validation only enforced character counts server-side, which allowed malformed payloads to slip through and be replayed into the frontend. 

### Description
- Added server-side constraints in `supabase.sql` to enforce letter-only values for `name`, `city`, `state`, and `country` using regex checks and to cap byte size with `octet_length(...) <= 80` to block oversized multibyte payloads. 
- Extended the `INSERT` RLS policy to include the same letter-only and `octet_length` checks so direct writes via the anon key are rejected at the DB boundary. 
- Hardened the frontend (`index.html`) read path by adding `sanitizeLettersOnlyText()` and using it in `sanitizeFetchedReports()` so fetched location fields are normalized to letters/spaces and trimmed to the browse field length before rendering. 
- Changes touch `supabase.sql` and `index.html` to provide defense-in-depth: server-side enforcement plus client-side sanitization of already-stored rows. 

### Testing
- Ran a repository scan to confirm the new sanitizer is present and referenced in the fetch/render path. 
- Ran `git diff --check` which returned no whitespace or diff issues. 
- Manual inspection (automated commands used: `rg`/`sed`) verified the DB constraints and RLS policy include the new regex and `octet_length` guards and that the frontend sanitizes fetched values; no automated test failures were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eefdd40318832fbff570d276d47a33)