### PR TITLE
Prevent header status shift during loading animation

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,6 +122,9 @@
     }
     .report-count {
       margin: 0;
+      display: inline-block;
+      min-width: 30ch;
+      white-space: nowrap;
       font-size: 0.92rem;
       color: #93c5fd;
       letter-spacing: 0.02em;


### PR DESCRIPTION
### Motivation
- Prevent the header text from shifting when the `report-count` loading dots animate, which caused the status paragraph to re-center.

### Description
- Update `index.html` CSS for `.report-count` to `display: inline-block`, `min-width: 30ch`, and `white-space: nowrap` so the counter keeps a stable width during animation.

### Testing
- No automated tests exist for this UI change and none were run; the change is a small CSS tweak that was committed to the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef08bd2760832f8154706bfd7f264e)