### PR TITLE
Fetch reports from Worker endpoint in loadReports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1851,35 +1851,46 @@ function addStoryTimestamp() {
     }
 
     async function loadReports() {
-  browseMessage.textContent = 'Loading reports...';
-  browseMessage.className = 'message';
-  startReportCountLoadingAnimation();
+      browseMessage.textContent = 'Loading reports...';
+      browseMessage.className = 'message';
+      startReportCountLoadingAnimation();
 
-  try {
-    const reports = await fetchAllReportsFromSupabase(1000);
+      const WORKER_URL = 'https://api.namehim.app/filtered-reports';
 
-    allReports = sanitizeFetchedReports(reports || []);
-    window.allReports = allReports;
-    hasLoadedReports = true;
-    updateReportCount(allReports.length);
-    updateBrowseViewFromRoute({ preserveBrowsePage: true });
-    browseMessage.textContent = allReports.length
-      ? `Loaded ${allReports.length} report(s).`
-      : 'No reports yet. Be the first to submit.';
-    browseMessage.className = 'message';
-  } catch (error) {
-    console.error('Failed to load reports from Supabase:', error);
-    browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';
-    browseMessage.className = 'message error';
-    allReports = [];
-    window.allReports = allReports;
-    hasLoadedReports = true;
-    updateReportCount(0);
-    renderPagedReports([], 1);
-  } finally {
-    stopReportCountLoadingAnimation();
-  }
-}
+      try {
+        const response = await fetch(WORKER_URL);
+        if (!response.ok) {
+          throw new Error(`Worker returned ${response.status}`);
+        }
+        const reports = await response.json();
+
+        if (!Array.isArray(reports)) {
+          throw new Error('Worker did not return an array');
+        }
+
+        // Sanitize the reports (keep your existing sanitization logic)
+        allReports = sanitizeFetchedReports(reports);
+        window.allReports = allReports;
+        hasLoadedReports = true;
+        updateReportCount(allReports.length);
+        updateBrowseViewFromRoute({ preserveBrowsePage: true });
+        browseMessage.textContent = allReports.length
+          ? `Loaded ${allReports.length} report(s).`
+          : 'No reports yet. Be the first to submit.';
+        browseMessage.className = 'message';
+      } catch (error) {
+        console.error('Failed to load reports via Worker:', error);
+        browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';
+        browseMessage.className = 'message error';
+        allReports = [];
+        window.allReports = allReports;
+        hasLoadedReports = true;
+        updateReportCount(0);
+        renderPagedReports([], 1);
+      } finally {
+        stopReportCountLoadingAnimation();
+      }
+    }
 
     function setSingleStoryControlsVisible(visible) {
       if (!singleStoryControls) {


### PR DESCRIPTION
### Motivation
- Replace the previous Supabase pagination helper with a Worker-based endpoint to centralize/standardize report filtering and retrieval in the client `loadReports` flow.
- Add defensive checks to ensure HTTP success and that the Worker returns an array before proceeding.

### Description
- Replaced the `fetchAllReportsFromSupabase(1000)` call inside `async function loadReports()` with a `fetch` to `https://api.namehim.app/filtered-reports` stored in `WORKER_URL`.
- Added response validation: check `response.ok` and verify `Array.isArray(reports)`, throwing errors when invalid.
- Continued to call `sanitizeFetchedReports(reports)`, set `window.allReports`, `hasLoadedReports = true`, call `updateReportCount()` and `updateBrowseViewFromRoute({ preserveBrowsePage: true })`, and update `browseMessage` on success.
- On error, log with `console.error('Failed to load reports via Worker:', error)`, set `allReports = []`, update `window.allReports`, set `hasLoadedReports = true`, call `updateReportCount(0)` and `renderPagedReports([], 1)`, and preserve the loading animation cleanup with `stopReportCountLoadingAnimation()` in `finally`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef0d781af0832f920a40b41495b074)