### PR TITLE
Load all browse reports via paginated Supabase query

### DIFF
--- a/index.html
+++ b/index.html
@@ -1855,20 +1855,8 @@ function addStoryTimestamp() {
       browseMessage.className = 'message';
       startReportCountLoadingAnimation();
 
-      const WORKER_URL = 'https://api.namehim.app/filtered-reports';
-
       try {
-        const response = await fetch(WORKER_URL);
-        if (!response.ok) {
-          throw new Error(`Worker returned ${response.status}`);
-        }
-        const reports = await response.json();
-
-        if (!Array.isArray(reports)) {
-          throw new Error('Worker did not return an array');
-        }
-
-        // Sanitize the reports (keep your existing sanitization logic)
+        const reports = await fetchAllReportsFromSupabase();
         allReports = sanitizeFetchedReports(reports);
         window.allReports = allReports;
         hasLoadedReports = true;
@@ -1879,7 +1867,7 @@ function addStoryTimestamp() {
           : 'No reports yet. Be the first to submit.';
         browseMessage.className = 'message';
       } catch (error) {
-        console.error('Failed to load reports via Worker:', error);
+        console.error('Failed to load reports from Supabase:', error);
         browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';
         browseMessage.className = 'message error';
         allReports = [];


### PR DESCRIPTION
### Motivation
- The browse page was loading reports via a Worker endpoint that returned a capped result (1,000), causing the UI and report count to not reflect the full dataset.
- Use the existing paginated Supabase query to ensure the Browse table and report count show all reports.

### Description
- Replaced the Worker-based fetch in `loadReports` with a call to `fetchAllReportsFromSupabase()` and then passed the results through `sanitizeFetchedReports` into `allReports`.
- Ensured the UI and internal state are updated from the full dataset by calling `updateReportCount(allReports.length)` and `updateBrowseViewFromRoute({ preserveBrowsePage: true })` after loading.
- Updated the error log message to indicate failures occur "from Supabase" while preserving existing error handling and user-facing messages.

### Testing
- No automated tests were run because this repository does not include an automated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef132210c0832f8f99dae704cd4fd3)