### PR TITLE
Load reports from worker endpoint and remove Supabase batch loader

### DIFF
--- a/index.html
+++ b/index.html
@@ -1774,35 +1774,6 @@ function addStoryTimestamp() {
     }
 
 
-    async function fetchAllReportsFromSupabase(batchSize = 1000) {
-      const collected = [];
-      let from = 0;
-
-      while (true) {
-        const to = from + batchSize - 1;
-        const { data, error } = await supabaseClient
-          .from('reports')
-          .select('id,name,city,state,country,categories,created_at')
-          .order('created_at', { ascending: false })
-          .range(from, to);
-
-        if (error) {
-          throw error;
-        }
-
-        const rows = Array.isArray(data) ? data : [];
-        collected.push(...rows);
-
-        if (rows.length < batchSize) {
-          break;
-        }
-
-        from += batchSize;
-      }
-
-      return collected;
-    }
-
     function applySearchFilter(options = {}) {
       const preservePage = Boolean(options.preservePage);
       const reportId = getReportIdFromUrl();
@@ -1854,9 +1825,19 @@ function addStoryTimestamp() {
       browseMessage.textContent = 'Loading reports...';
       browseMessage.className = 'message';
       startReportCountLoadingAnimation();
+      const WORKER_URL = 'https://api.namehim.app/filtered-reports';
 
       try {
-        const reports = await fetchAllReportsFromSupabase();
+        const response = await fetch(WORKER_URL);
+        if (!response.ok) {
+          throw new Error(`Worker returned ${response.status}`);
+        }
+        const reports = await response.json();
+
+        if (!Array.isArray(reports)) {
+          throw new Error('Worker did not return an array');
+        }
+
         allReports = sanitizeFetchedReports(reports);
         window.allReports = allReports;
         hasLoadedReports = true;
@@ -1867,7 +1848,7 @@ function addStoryTimestamp() {
           : 'No reports yet. Be the first to submit.';
         browseMessage.className = 'message';
       } catch (error) {
-        console.error('Failed to load reports from Supabase:', error);
+        console.error('Failed to load reports via Worker:', error);
         browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';
         browseMessage.className = 'message error';
         allReports = [];


### PR DESCRIPTION
### Motivation
- Move report loading to a centralized Worker endpoint to avoid client-side batched Supabase queries and simplify the browser loader.

### Description
- Removed the unused `fetchAllReportsFromSupabase` helper from `index.html`.
- Replaced `loadReports` to `fetch` from `https://api.namehim.app/filtered-reports`, validate the HTTP status, and ensure the payload is an array before sanitizing.
- Updated the error log message to `Failed to load reports via Worker:` and preserved the existing UI fallback behavior and report-count animation handling.
- Kept downstream behaviors intact: `window.allReports` population, `updateReportCount`, `updateBrowseViewFromRoute`, and `renderPagedReports` on errors.

### Testing
- Ran `rg -n "fetchAllReportsFromSupabase|WORKER_URL|Failed to load reports via Worker" index.html` to confirm the old helper was removed and the new worker URL and log string are present, which succeeded.
- Verified the diff with `git show --stat --oneline HEAD` and confirmed the single-file change, which succeeded.
- Performed `git status` and a `git commit` for the change, both of which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef20f488d4832f8f8f1450aefb7f58)