### PR TITLE
Standardize USA display and decouple map ↔ dropdown interactions

### DIFF
--- a/index.html
+++ b/index.html
@@ -799,7 +799,7 @@
               <option value="United Arab Emirates">United Arab Emirates</option>
               <option value="United Kingdom">United Kingdom</option>
               <option value="United Republic of Tanzania">United Republic of Tanzania</option>
-              <option value="United States of America">United States of America</option>
+              <option value="USA">USA</option>
               <option value="Uruguay">Uruguay</option>
               <option value="Uzbekistan">Uzbekistan</option>
               <option value="Vanuatu">Vanuatu</option>
@@ -1102,6 +1102,7 @@
     const COUNTRY_FILTER_ALIASES = {
       'united states': 'united states',
       'united states america': 'united states',
+      'united states ame': 'united states',
       'u s': 'united states',
       'u s a': 'united states',
       usa: 'united states',
@@ -1146,7 +1147,8 @@
 
       const uniqueByNormalized = new Map();
       const addCountryOption = (rawValue) => {
-        const value = String(rawValue || '').trim();
+        const sourceValue = String(rawValue || '').trim();
+        const value = isUnitedStatesCountryValue(sourceValue) ? 'USA' : sourceValue;
         if (!value) {
           return;
         }
@@ -1232,6 +1234,14 @@
     }
 
     window.setCountryDropdownValue = setCountryDropdownValue;
+
+    function clearBrowseLocationDropdownValues() {
+      setCountryDropdownValue('');
+      setStateDropdownValue('');
+      updateBrowseLocationFiltersUI();
+    }
+
+    window.clearBrowseLocationDropdownValues = clearBrowseLocationDropdownValues;
 
 function filterReportsByState(stateFullName) {
   const searchInput = document.getElementById('report-search');
@@ -1680,7 +1690,7 @@ function addStoryTimestamp() {
     function renderStateField() {
       const selectedCountry = (countryField.value || '').trim();
 
-      if (selectedCountry === 'United States of America') {
+      if (isUnitedStatesCountryValue(selectedCountry)) {
         const stateOptions = US_STATES
           .map((state) => '<option value="' + escapeHTML(state) + '">' + escapeHTML(state) + '</option>')
           .join('');
@@ -2346,25 +2356,27 @@ function addStoryTimestamp() {
       if (browseStateSelect) {
         browseStateSelect.addEventListener('change', function onStateSelectChange() {
           const selectedState = browseStateSelect.value;
+          if (typeof window.clearSelectedMapState === 'function') {
+            window.clearSelectedMapState();
+          }
+          if (typeof window.clearSelectedWorldCountry === 'function') {
+            window.clearSelectedWorldCountry();
+          }
           if (!selectedState) {
-            if (typeof window.clearSelectedMapState === 'function') {
-              window.clearSelectedMapState();
-            }
             reportSearch.value = '';
             applySearchFilter();
             return;
           }
 
-          if (typeof window.selectStateOnMapByName === 'function') {
-            window.selectStateOnMapByName(selectedState);
-          } else {
-            filterReportsByState(selectedState);
-          }
+          filterReportsByState(selectedState);
         });
       }
       if (browseCountrySelect) {
         browseCountrySelect.addEventListener('change', function onCountrySelectChange() {
-          if (browseCountrySelect.value === '' && typeof window.clearSelectedWorldCountry === 'function') {
+          if (typeof window.clearSelectedMapState === 'function') {
+            window.clearSelectedMapState();
+          }
+          if (typeof window.clearSelectedWorldCountry === 'function') {
             window.clearSelectedWorldCountry();
           }
           updateBrowseLocationFiltersUI();
@@ -2374,6 +2386,16 @@ function addStoryTimestamp() {
           }
         });
       }
+      window.filterReportsByStateFromMap = function filterReportsByStateFromMap(stateFullName) {
+        clearBrowseLocationDropdownValues();
+        filterReportsByState(stateFullName);
+      };
+
+      window.filterReportsByCountryFromMap = function filterReportsByCountryFromMap(countryName) {
+        clearBrowseLocationDropdownValues();
+        reportSearch.value = String(countryName || '').trim();
+        applySearchFilter();
+      };
       browsePagination.addEventListener('click', function onPaginationClick(event) {
         const target = event.target.closest('button');
         if (!target) {
@@ -2471,6 +2493,10 @@ function initWorldMapToggle() {
 
 function initWorldMapInteractions() {
   window.applyCountryFilterFromWorldMap = function applyCountryFilterFromWorldMap(countryName) {
+    if (typeof window.filterReportsByCountryFromMap === 'function') {
+      window.filterReportsByCountryFromMap(countryName);
+      return;
+    }
     filterReportsByCountry(countryName);
   };
 }
@@ -2548,9 +2574,11 @@ function applyWorldMapSelectionById(stateId, shouldFilter) {
 
   const countryName = getWorldMapCountryDisplayName(selectedWorldCountryId);
   if (shouldFilter) {
-    filterReportsByCountry(countryName);
-  } else {
-    setCountryDropdownValue(countryName);
+    if (typeof window.filterReportsByCountryFromMap === 'function') {
+      window.filterReportsByCountryFromMap(countryName);
+    } else {
+      filterReportsByCountry(countryName);
+    }
   }
 }
 
@@ -2598,18 +2626,10 @@ function attachWorldMapHooks() {
 
 function syncWorldMapWithCurrentFilters() {
   updateWorldMapStateDescriptions();
-
-  const selectedCountry = String((browseCountrySelect && browseCountrySelect.value) || '').trim();
-  const stateId = getWorldCountryIdByName(selectedCountry);
-  if (!stateId) {
-    if (selectedWorldCountryId) {
-      setWorldCountryFill(selectedWorldCountryId, WORLD_MAP_DEFAULT_COLOR);
-    }
-    selectedWorldCountryId = null;
-    return;
+  if (selectedWorldCountryId) {
+    setWorldCountryFill(selectedWorldCountryId, WORLD_MAP_DEFAULT_COLOR);
   }
-
-  applyWorldMapSelectionById(stateId, false);
+  selectedWorldCountryId = null;
 }
 
 window.clearSelectedWorldCountry = function clearSelectedWorldCountry() {

--- a/usmap.js
+++ b/usmap.js
@@ -69,25 +69,25 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
     }
   }
 
-  function syncStateDropdown(stateName) {
-    if (typeof window.setStateDropdownValue === "function") {
-      window.setStateDropdownValue(stateName || "");
-    }
-  }
-
   function selectState(stateId, shouldFilter) {
     if (!stateId) {
       setSelectedState(null);
-      syncStateDropdown("");
       return;
     }
 
     setSelectedState(stateId);
     var stateName = getStateName(stateId);
-    syncStateDropdown(stateName);
 
-    if (shouldFilter && typeof window.filterReportsByState === "function") {
-      window.filterReportsByState(stateName);
+    if (shouldFilter) {
+      if (typeof window.clearBrowseLocationDropdownValues === "function") {
+        window.clearBrowseLocationDropdownValues();
+      }
+
+      if (typeof window.filterReportsByStateFromMap === "function") {
+        window.filterReportsByStateFromMap(stateName);
+      } else if (typeof window.filterReportsByState === "function") {
+        window.filterReportsByState(stateName);
+      }
     }
   }
 

--- a/worldmap.js
+++ b/worldmap.js
@@ -23,6 +23,7 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
   var COUNTRY_COUNT_ALIASES = {
     "united states": "united states",
     "united states america": "united states",
+    "united states ame": "united states",
     "u s": "united states",
     "u s a": "united states",
     usa: "united states",
@@ -106,9 +107,13 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
   function getCountryName(countryId) {
     var mapdata = window.simplemaps_worldmap_mapdata || {};
     var countrySpecific = mapdata.state_specific || {};
-    return countrySpecific[countryId] && countrySpecific[countryId].name
+    var countryName = countrySpecific[countryId] && countrySpecific[countryId].name
       ? countrySpecific[countryId].name
       : countryId;
+    if (normalizeCountryForCount(countryName) === "united states") {
+      return "USA";
+    }
+    return countryName;
   }
 
   function getRegionName(regionId) {
@@ -164,62 +169,6 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     }
 
     return count;
-  }
-
-  function resolveCountrySelection(countryName) {
-    var select = document.getElementById("browse-country-select");
-    if (!select) {
-      return countryName;
-    }
-
-    var options = Array.prototype.slice.call(select.options || []);
-    var countryAliases = {
-      "united states": "United States of America",
-      "usa": "United States of America",
-      "us": "United States of America",
-      "russia": "Russian Federation",
-      "south korea": "Republic of Korea",
-      "north korea": "Democratic People's Republic of Korea",
-      "czech republic": "Czechia",
-      "ivory coast": "Cote d'Ivoire",
-      "cape verde": "Cabo Verde",
-      "the gambia": "Gambia",
-      "republic of congo": "Congo",
-      "democratic republic congo": "Democratic Republic of the Congo",
-      "palestine": "State of Palestine"
-    };
-
-    var exactValue = "";
-    var source = String(countryName || "").trim();
-    var normalizedSource = normalizeText(source);
-    var aliased = countryAliases[normalizedSource] || source;
-    var normalizedAliased = normalizeText(aliased);
-    var i;
-
-    for (i = 0; i < options.length; i += 1) {
-      if (String(options[i].value || "") === aliased) {
-        exactValue = String(options[i].value || "");
-        break;
-      }
-    }
-
-    if (exactValue) {
-      return exactValue;
-    }
-
-    for (i = 0; i < options.length; i += 1) {
-      if (normalizeText(options[i].value) === normalizedAliased) {
-        return String(options[i].value || "");
-      }
-    }
-
-    for (i = 0; i < options.length; i += 1) {
-      if (normalizeText(options[i].textContent) === normalizedAliased) {
-        return String(options[i].value || "");
-      }
-    }
-
-    return source;
   }
 
   function setCountryFill(countryId, color) {
@@ -384,14 +333,10 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
 
   function clearCountrySelection() {
     setSelectedCountry(null);
-    if (typeof window.setCountryDropdownValue === "function") {
-      window.setCountryDropdownValue("");
-    }
   }
 
   function selectCountry(countryId, shouldFilter) {
     var countryName;
-    var mappedCountry;
 
     if (!countryId) {
       clearCountrySelection();
@@ -399,15 +344,17 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     }
 
     countryName = getCountryName(countryId);
-    mappedCountry = resolveCountrySelection(countryName);
     setSelectedCountry(countryId);
 
-    if (typeof window.setCountryDropdownValue === "function") {
-      window.setCountryDropdownValue(mappedCountry);
-    }
-
-    if (shouldFilter && typeof window.filterReportsByCountry === "function") {
-      window.filterReportsByCountry(mappedCountry);
+    if (shouldFilter) {
+      if (typeof window.clearBrowseLocationDropdownValues === "function") {
+        window.clearBrowseLocationDropdownValues();
+      }
+      if (typeof window.filterReportsByCountryFromMap === "function") {
+        window.filterReportsByCountryFromMap(countryName);
+      } else if (typeof window.filterReportsByCountry === "function") {
+        window.filterReportsByCountry(countryName);
+      }
     }
   }
 


### PR DESCRIPTION
### Motivation
- Fix an incorrect / truncated country label and make country display consistent everywhere by using the short form `USA` for United States values.
- Ensure map interactions and dropdown filters behave independently so clicking a map region still filters results but does not unexpectedly overwrite dropdown selections.

### Description
- Replaced the submit/browse country option for the United States with `USA` and added normalization aliases so variants like `United States of AME` map to the US bucket during filtering and rendering (`index.html`).
- Canonicalized browse country options generation so any source US value is shown as `USA` in the country select list and updated `renderStateField` to detect US variants via the normalized helper (`index.html`).
- Added `clearBrowseLocationDropdownValues()` plus map-driven wrappers `filterReportsByStateFromMap()` and `filterReportsByCountryFromMap()` to clear the dropdowns before applying map-based filtering (`index.html`).
- Decoupled behavior in the US map module so selecting a state on the US map clears browse dropdowns and calls the new map-specific filter helper instead of writing into the dropdown (`usmap.js`).
- Updated world map logic to normalize US variants, return/display `USA` for the US, stop writing country dropdown values on map click, and call the new map-specific filter helpers while also removing the previous sync-from-dropdown-to-map behavior (`worldmap.js`).

### Testing
- Performed JavaScript syntax/parse checks with `node --check usmap.js` which succeeded.
- Performed JavaScript syntax/parse checks with `node --check worldmap.js` which succeeded.
- No automated browser UI tests were available in this environment, so runtime verification of in-browser interactions should be validated in a staging browser before deploying to production.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef2e856358832faa32373820f7a90e)