### PR TITLE
Fix country dropdown filtering and world map sync

### DIFF
--- a/index.html
+++ b/index.html
@@ -2373,11 +2373,15 @@ function addStoryTimestamp() {
       }
       if (browseCountrySelect) {
         browseCountrySelect.addEventListener('change', function onCountrySelectChange() {
+          const selectedCountry = String(browseCountrySelect.value || '').trim();
           if (typeof window.clearSelectedMapState === 'function') {
             window.clearSelectedMapState();
           }
-          if (typeof window.clearSelectedWorldCountry === 'function') {
+          if (!selectedCountry && typeof window.clearSelectedWorldCountry === 'function') {
             window.clearSelectedWorldCountry();
+          }
+          if (selectedCountry && typeof window.selectWorldCountryOnMapByName === 'function') {
+            window.selectWorldCountryOnMapByName(selectedCountry);
           }
           updateBrowseLocationFiltersUI();
           applySearchFilter();
@@ -2389,8 +2393,10 @@ function addStoryTimestamp() {
       };
 
       window.filterReportsByCountryFromMap = function filterReportsByCountryFromMap(countryName) {
-        clearBrowseLocationDropdownValues();
-        reportSearch.value = String(countryName || '').trim();
+        setCountryDropdownValue(countryName);
+        setStateDropdownValue('');
+        reportSearch.value = '';
+        updateBrowseLocationFiltersUI();
         applySearchFilter();
       };
       browsePagination.addEventListener('click', function onPaginationClick(event) {
@@ -2639,7 +2645,7 @@ window.clearSelectedWorldCountry = function clearSelectedWorldCountry() {
 window.selectWorldCountryOnMapByName = function selectWorldCountryOnMapByName(countryName) {
   const stateId = getWorldCountryIdByName(countryName);
   if (stateId) {
-    applyWorldMapSelectionById(stateId, true);
+    applyWorldMapSelectionById(stateId, false);
   }
 };
 

--- a/worldmap.js
+++ b/worldmap.js
@@ -347,9 +347,6 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
     setSelectedCountry(countryId);
 
     if (shouldFilter) {
-      if (typeof window.clearBrowseLocationDropdownValues === "function") {
-        window.clearBrowseLocationDropdownValues();
-      }
       if (typeof window.filterReportsByCountryFromMap === "function") {
         window.filterReportsByCountryFromMap(countryName);
       } else if (typeof window.filterReportsByCountry === "function") {


### PR DESCRIPTION
### Motivation
- Selecting a country from the browse dropdown or the world map was not reliably applying filters and often reset the dropdown back to the placeholder, producing no results; this change fixes that UX bug. 
- Map-driven selection and dropdown-driven selection could cause circular updates that cleared the user's selection; the change prevents re-triggering loops and keeps map highlighting and filters in sync. 

### Description
- Updated the browse-to-map flow in `index.html` so `filterReportsByCountryFromMap` now sets the country dropdown via `setCountryDropdownValue`, clears the state dropdown via `setStateDropdownValue('')`, clears the free-text search, calls `updateBrowseLocationFiltersUI()`, and then calls `applySearchFilter()` to show results. 
- Enhanced the `browseCountrySelect` `change` handler in `index.html` to detect an actual selection and call `selectWorldCountryOnMapByName(selectedCountry)` when a country is chosen, and to only clear the world-country selection when the dropdown becomes empty. 
- Changed `selectWorldCountryOnMapByName` in `index.html` to call `applyWorldMapSelectionById(stateId, false)` so the map highlight is synchronized without forcing another map->filter cycle. 
- Removed redundant clearing of browse dropdowns in `worldmap.js` inside `selectCountry`, preventing the map click handler from wiping the browse filters and causing the observed revert-to-default behavior. 

### Testing
- Inspected and traced changes with `rg` and `sed` to confirm the updated event handlers and functions were applied to `index.html` and `worldmap.js`. 
- Verified the edits were staged and committed successfully via `git status`, `git diff`, and `git commit`. 
- No automated unit tests were present or run; verification was done via static review of the modified handlers and integration points to ensure the selection->filter->map flow no longer clears the selected country and avoids circular re-entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef34c128d8832f8c63559937bb8718)