### PR TITLE
Sort browse-country dropdown using normalized names

### DIFF
--- a/index.html
+++ b/index.html
@@ -1194,9 +1194,15 @@
         addCountryOption(option.value || option.textContent);
       });
 
-      const sortedCountries = Array.from(uniqueByNormalized.values()).sort((a, b) =>
-        a.localeCompare(b, undefined, { sensitivity: 'base' })
-      );
+      const sortedCountries = Array.from(uniqueByNormalized.values()).sort((a, b) => {
+        const normalizedA = normalizeCountryForFiltering(a);
+        const normalizedB = normalizeCountryForFiltering(b);
+        const normalizedComparison = normalizedA.localeCompare(normalizedB, undefined, { sensitivity: 'base' });
+        if (normalizedComparison !== 0) {
+          return normalizedComparison;
+        }
+        return a.localeCompare(b, undefined, { sensitivity: 'base' });
+      });
 
       const countryOptions = sortedCountries
         .map((value) => {


### PR DESCRIPTION
### Motivation
- The country dropdown was ordering entries like `"Israel" (Occupied Palestine)` before lettered names because sorting used the raw string including leading punctuation, so the intent is to order countries alphabetically by their letter-based name while preserving the original displayed value. 
- Using the same normalization used for filtering ensures the browse list aligns with how countries are compared elsewhere in the code.

### Description
- Updated `populateBrowseCountrySelect` in `index.html` to sort country options by the normalized value returned from `normalizeCountryForFiltering` first. 
- Added a fallback tie-breaker that compares the raw values with `localeCompare` to keep ordering stable when normalized results match. 
- Preserved the actual option text and values so displayed strings (including leading symbols/quotes) are not changed.

### Testing
- Committed the change and ran `git status --short`, `git commit`, and `git show` which all completed successfully. 
- Ran `git diff --check HEAD~1 HEAD` to ensure no trailing-whitespace or diff-check issues and it reported clean. 
- Verified via code inspection that only `index.html` was modified and the updated comparator is used in `populateBrowseCountrySelect`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef3bc2a43c832f817fccb4928e60c6)