### PR TITLE
Update header status messaging and add Admin Log section

### DIFF
--- a/about.html
+++ b/about.html
@@ -322,6 +322,10 @@
         <section>
           <p>Contact: namehim.app@proton.me</p>
         </section>
+        <section>
+          <h3>Admin Log</h3>
+          <p><strong>2:00 a.m. April 27, 2026 (PDT):</strong> The site suffered a very intelligent malicious attack, but after many hours of problem solving and updating the site and the database, it has been fixed and should stop this from happening in the future. In this process, there may have been an accidental deletion of some entries, so if you submitted your entry around the time the site had between 18,000 and 21,000 reports, please check if your submission is still there. If it is not, feel free to submit again.</p>
+        </section>
       </article>
     </div>
   </main>

--- a/index.html
+++ b/index.html
@@ -533,7 +533,7 @@
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
         <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
-      <p class="header-status">The site suffered a very intelligent malicious attack, but after many hours of problem solving and updating the site and the database, it has been fixed and should stop this from happening in the future. In this process, there may have been an accidental deletion of some entries, so if you submitted your entry around the time the site had between 18,000 and 21,000 reports, please check if your submission is still there. If it is not, feel free to submit again.</p>
+      <p class="header-status">The site is being targeted by malicious actors who are trying to make it non-functional. Please see admin log for updates.</p>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Replace the lengthy incident notice in the homepage header with a short, current status directing users to an admin log for updates. 
- Preserve the original detailed incident message by moving it into an Admin Log on the About page with the requested timestamp `2:00 a.m. April 27, 2026 (PDT)`.

### Description
- Updated the homepage header message in `index.html` to: “The site is being targeted by malicious actors who are trying to make it non-functional. Please see admin log for updates.”
- Added an `Admin Log` section to `about.html` directly under the contact text and inserted the previous header incident text with the requested timestamp.
- Files changed: `index.html`, `about.html`.

### Testing
- Located and inspected occurrences with `rg -n "malicious|admin log|Contact" index.html about.html` and verified the original text location. (succeeded)
- Verified the edits via `git diff -- about.html index.html` and by printing file segments with `nl`/`sed` to confirm the new header line and new Admin Log section. (succeeded)
- Committed the changes with `git commit` and confirmed repository status with `git status --short`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efbe7b48b4832f9c16cee7b95bc3f1)