### PR TITLE
Add Puerto Rico to country dropdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -752,6 +752,7 @@
               <option value="Philippines">Philippines</option>
               <option value="Poland">Poland</option>
               <option value="Portugal">Portugal</option>
+              <option value="Puerto Rico">Puerto Rico</option>
               <option value="Qatar">Qatar</option>
               <option value="Republic of Korea">Republic of Korea</option>
               <option value="Republic of Moldova">Republic of Moldova</option>


### PR DESCRIPTION
Puerto Rico was missing from the country selection list in the submission form. This also makes it available in the browse/search country filter since that dropdown is populated from the same list.