### PR TITLE
Remove malicious attack status message from header

### DIFF
--- a/index.html
+++ b/index.html
@@ -533,7 +533,6 @@
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
         <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
-      <p class="header-status">The site is being targeted by malicious actors who are trying to make it non-functional. Please see admin log for updates.</p>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Remove an alarming status banner in the site header that declared the site was being targeted by malicious actors to restore the normal header appearance.

### Description
- Deleted the `<p class="header-status">…</p>` element from `index.html` and left the rest of the header markup and navigation unchanged.

### Testing
- Verified the text was removed with `rg -n "header-status|malicious actors" index.html` which returned no matches; attempted a screenshot with `npx --yes playwright screenshot file:///workspace/namehim/index.html /workspace/namehim/.artifacts/header-removed.png` but Playwright installation failed due to an npm registry 403 error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f085251b1c832fb964a6e8f8c6717c)