### PR TITLE
Add hidden Turnstile container for report-flag CAPTCHA

### DIFF
--- a/index.html
+++ b/index.html
@@ -879,6 +879,7 @@
       <span>Open source</span>
     </div>
   </footer>
+  <div id="flag-turnstile-container" class="cf-turnstile" data-sitekey="0x4AAAAAADCC51BDmfY6JgSc" data-theme="dark" style="display: none;"></div>
 
   <script>
     const routes = {


### PR DESCRIPTION
### Motivation
- Provide a hidden Cloudflare Turnstile widget container so the app can programmatically obtain CAPTCHA tokens when a user clicks “Report this entry” without displaying the widget in the UI.

### Description
- Inserted `<div id="flag-turnstile-container" class="cf-turnstile" data-sitekey="0x4AAAAAADCC51BDmfY6JgSc" data-theme="dark" style="display: none;"></div>` into `index.html` immediately after the `<footer>` element.

### Testing
- Verified the HTML diff contains the new `#flag-turnstile-container` using `git diff`/`nl` and searched the repo for the element, and the automated commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f093ea8f58832fbf42493be559d428)