### PR TITLE
Wait for Turnstile before executing flag captcha

### DIFF
--- a/index.html
+++ b/index.html
@@ -2040,6 +2040,13 @@ function addStoryTimestamp() {
       return tokenField && tokenField.value ? tokenField.value : '';
     }
 
+    function waitForTurnstile() {
+      return new Promise((resolve) => {
+        if (window.turnstile) resolve();
+        else setTimeout(() => resolve(waitForTurnstile()), 100);
+      });
+    }
+
     function resetTurnstileWidget() {
       if (window.turnstile && typeof window.turnstile.reset === 'function') {
         // Find the first turnstile iframe and reset
@@ -2262,6 +2269,7 @@ function addStoryTimestamp() {
 
         let token;
         try {
+          await waitForTurnstile();
           // Execute the hidden Turnstile widget (this will show a challenge if needed)
           token = await window.turnstile.execute(turnstileWidget);
         } catch (err) {


### PR DESCRIPTION
### Motivation
- Prevent a race condition where `window.turnstile` may not be available yet when attempting to call `turnstile.execute`, ensuring CAPTCHA execution only runs after the Turnstile script has loaded.

### Description
- Add `waitForTurnstile()` which polls every 100ms until `window.turnstile` exists, and call `await waitForTurnstile();` immediately before invoking `window.turnstile.execute(turnstileWidget)` in the report-entry click handler.

### Testing
- Verified the change by inspecting the diff and file lines with `git diff` and `nl`, and committed the updated `index.html` with `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0964ba178832fb7998f860f5b449d)