### PR TITLE
Add persistent footer dark mode toggle across all pages

### DIFF
--- a/about.html
+++ b/about.html
@@ -36,6 +36,14 @@
       --muted: #9ca3af;
       --border: #334155;
     }
+    body.light-mode {
+      --bg: #ffffff;
+      --panel: #ffffff;
+      --panel-2: #f8fafc;
+      --text: #000000;
+      --muted: #374151;
+      --border: #000000;
+    }
 
     * { box-sizing: border-box; }
 
@@ -202,6 +210,12 @@
     .footer-inner a {
       color: inherit;
     }
+    .theme-toggle-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+    }
+    .theme-toggle-wrap input { accent-color: #2563eb; }
 
     @media (max-width: 760px) {
       .container {
@@ -339,11 +353,36 @@
         <a href="https://github.com/namehim/namehim">GitHub</a>
       </div>
       <span>Open source</span>
+      <label class="theme-toggle-wrap" for="theme-toggle">
+        <span>Dark mode</span>
+        <input id="theme-toggle" type="checkbox" checked />
+      </label>
     </div>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script>
+    const THEME_STORAGE_KEY = 'namehim_dark_mode';
+    const themeToggle = document.getElementById('theme-toggle');
+
+    function applyTheme(isDarkMode) {
+      document.body.classList.toggle('light-mode', !isDarkMode);
+      if (themeToggle) {
+        themeToggle.checked = isDarkMode;
+      }
+    }
+
+    const storedThemePreference = localStorage.getItem(THEME_STORAGE_KEY);
+    applyTheme(storedThemePreference !== 'false');
+
+    if (themeToggle) {
+      themeToggle.addEventListener('change', () => {
+        const isDarkMode = themeToggle.checked;
+        localStorage.setItem(THEME_STORAGE_KEY, isDarkMode ? 'true' : 'false');
+        applyTheme(isDarkMode);
+      });
+    }
+
     function formatReportTotal(total) {
       const parsedTotal = Number(total) || 0;
       return parsedTotal.toLocaleString('en-US');

--- a/index.html
+++ b/index.html
@@ -39,6 +39,17 @@
       --danger: #ef4444;
       --success: #22c55e;
     }
+    body.light-mode {
+      --bg: #ffffff;
+      --panel: #ffffff;
+      --panel-2: #f8fafc;
+      --text: #000000;
+      --muted: #374151;
+      --border: #000000;
+      --accent: #2563eb;
+      --danger: #b91c1c;
+      --success: #166534;
+    }
 
     * { box-sizing: border-box; }
 
@@ -439,6 +450,12 @@
     }
 
     .footer-inner a { color: inherit; }
+    .theme-toggle-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+    }
+    .theme-toggle-wrap input { accent-color: var(--accent); }
 
 
     @media (max-width: 760px) {
@@ -883,6 +900,10 @@
         <a href="https://github.com/namehim/namehim">GitHub</a>
       </div>
       <span>Open source</span>
+      <label class="theme-toggle-wrap" for="theme-toggle">
+        <span>Dark mode</span>
+        <input id="theme-toggle" type="checkbox" checked />
+      </label>
     </div>
   </footer>
 
@@ -960,6 +981,30 @@
     const approvedStoriesHeading = document.getElementById('approved-stories-heading');
 
     const STORY_RATE_LIMIT_KEY = 'story_submission_timestamps';
+    const THEME_STORAGE_KEY = 'namehim_dark_mode';
+    const themeToggle = document.getElementById('theme-toggle');
+
+    function applyTheme(isDarkMode) {
+      document.body.classList.toggle('light-mode', !isDarkMode);
+      if (themeToggle) {
+        themeToggle.checked = isDarkMode;
+      }
+    }
+
+    function loadThemePreference() {
+      const storedPreference = localStorage.getItem(THEME_STORAGE_KEY);
+      applyTheme(storedPreference !== 'false');
+    }
+
+    if (themeToggle) {
+      themeToggle.addEventListener('change', () => {
+        const isDarkMode = themeToggle.checked;
+        localStorage.setItem(THEME_STORAGE_KEY, isDarkMode ? 'true' : 'false');
+        applyTheme(isDarkMode);
+      });
+    }
+
+    loadThemePreference();
 
     const US_STATES = [
       'Alabama', 'Alaska', 'Arizona', 'Arkansas', 'California', 'Colorado', 'Connecticut', 'Delaware',

--- a/resources.html
+++ b/resources.html
@@ -19,6 +19,15 @@
       --border: #334155;
       --accent: #60a5fa;
     }
+    body.light-mode {
+      --bg: #ffffff;
+      --panel: #ffffff;
+      --panel-2: #f8fafc;
+      --text: #000000;
+      --muted: #374151;
+      --border: #000000;
+      --accent: #2563eb;
+    }
     * { box-sizing: border-box; }
     body {
       margin: 0;
@@ -113,6 +122,19 @@
       font-size: 0.82rem;
       padding: 1rem 0 1.4rem;
     }
+    .footer-inner {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.5rem;
+    }
+    .theme-toggle-wrap {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.45rem;
+    }
+    .theme-toggle-wrap input { accent-color: var(--accent); }
   </style>
 </head>
 <body>
@@ -150,17 +172,44 @@
   </main>
 
   <footer>
-    <div class="container">
-      <a href="index.html#/browse">Browse</a> ·
-      <a href="index.html#/submit">Submit</a> ·
-      <a href="index.html#/community">Community</a> ·
-      <a href="resources.html">Resources</a> ·
-      <a href="about.html">About</a> ·
-      <span>© <span id="year"></span> NameHim</span>
+    <div class="container footer-inner">
+      <div>
+        <a href="index.html#/browse">Browse</a> ·
+        <a href="index.html#/submit">Submit</a> ·
+        <a href="index.html#/community">Community</a> ·
+        <a href="resources.html">Resources</a> ·
+        <a href="about.html">About</a> ·
+        <span>© <span id="year"></span> NameHim</span>
+      </div>
+      <label class="theme-toggle-wrap" for="theme-toggle">
+        <span>Dark mode</span>
+        <input id="theme-toggle" type="checkbox" checked />
+      </label>
     </div>
   </footer>
 
   <script>
+    const THEME_STORAGE_KEY = 'namehim_dark_mode';
+    const themeToggle = document.getElementById('theme-toggle');
+
+    function applyTheme(isDarkMode) {
+      document.body.classList.toggle('light-mode', !isDarkMode);
+      if (themeToggle) {
+        themeToggle.checked = isDarkMode;
+      }
+    }
+
+    const storedThemePreference = localStorage.getItem(THEME_STORAGE_KEY);
+    applyTheme(storedThemePreference !== 'false');
+
+    if (themeToggle) {
+      themeToggle.addEventListener('change', () => {
+        const isDarkMode = themeToggle.checked;
+        localStorage.setItem(THEME_STORAGE_KEY, isDarkMode ? 'true' : 'false');
+        applyTheme(isDarkMode);
+      });
+    }
+
     document.getElementById('year').textContent = new Date().getFullYear();
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Provide a single, accessible control in the footer to switch between dark and a white/black light scheme so users can change theme from any page.
- Persist the choice across pages and visits so a user who toggles theme on one page will see the same theme by default on other pages.

### Description
- Added a light-theme CSS variable override under `body.light-mode` in `index.html`, `about.html`, and `resources.html` to define the white background, black text, and black borders palette.
- Inserted a footer toggle control (`<label class="theme-toggle-wrap"><span>Dark mode</span><input id="theme-toggle" type="checkbox" checked /></label>`) into the footer of the three pages so the control appears site-wide.
- Added JavaScript that reads and writes the `localStorage` key `namehim_dark_mode`, applies the `light-mode` class on `document.body` on load, and updates the preference when the toggle changes.
- The toggle defaults to checked (dark mode on) and unchecking it activates the requested white/black light appearance.

### Testing
- Programmatically inspected the updated files (`index.html`, `about.html`, `resources.html`) and confirmed the `body.light-mode` CSS, footer toggle markup, and the theme JS using the `namehim_dark_mode` key were added.
- Verified the theme application logic toggles the `light-mode` class and updates the stored preference during static inspection of the inserted JavaScript.
- No automated unit tests were present; repository file checks and static reviews of the diffs succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1fbdaecac832f9b84fbceeb67f020)