### PR TITLE
Load map scripts before main app initialization

### DIFF
--- a/index.html
+++ b/index.html
@@ -538,6 +538,16 @@
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+  <script src="mapdata.js?v=2026-04-24-3"></script>
+  <script src="usmap.js?v=2026-04-24-4"></script>
+  <script src="wmapdata.js?v=2026-04-25-1"></script>
+  <script>
+    if (window.simplemaps_worldmap_mapdata && window.simplemaps_worldmap_mapdata.main_settings) {
+      window.simplemaps_worldmap_mapdata.main_settings.div = 'world-map';
+      window.simplemaps_worldmap_mapdata.main_settings.auto_load = 'yes';
+    }
+  </script>
+  <script src="worldmap.js?v=2026-04-25-4"></script>
 </head>
 <body>
   <div class="disclaimer">
@@ -2901,17 +2911,5 @@ window.setTimeout(function initializeWorldMapHooks() {
 
     init();
   </script>
-  <!-- At the end of your <body>, before the closing </body> tag -->
-<script src="mapdata.js?v=2026-04-24-3"></script>
-<script src="usmap.js?v=2026-04-24-4"></script>
-<script src="wmapdata.js?v=2026-04-25-1"></script>
-<script>
-  if (window.simplemaps_worldmap_mapdata && window.simplemaps_worldmap_mapdata.main_settings) {
-    window.simplemaps_worldmap_mapdata.main_settings.div = 'world-map';
-    window.simplemaps_worldmap_mapdata.main_settings.auto_load = 'yes';
-  }
-</script>
-<script src="worldmap.js?v=2026-04-25-4"></script>
-
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- The app calls `init()` and map update logic before the map bundles load, leaving `window.simplemaps_*_mapdata` undefined and resulting in blank or uninitialized maps.
- Ensuring map data and `worldmap` globals exist before the main inline script runs fixes the race condition and allows the maps to render and receive updates.

### Description
- Moved `mapdata.js`, `usmap.js`, `wmapdata.js`, and `worldmap.js` into the `<head>` so they load before the main inline application script in `index.html`.
- Preserved the `worldmap` configuration override (`main_settings.div = 'world-map'` and `auto_load = 'yes'`) and placed it prior to `worldmap.js` being loaded.
- Removed the duplicate map script block from the end of the `<body>` so the scripts are only loaded once in the correct order.

### Testing
- Used `rg` to locate references to the map scripts and confirm their previous placement, and the search completed successfully.
- Applied an automated edit via a short Python script to move the script tags and the edit completed without errors.
- Inspected the updated `index.html` head and body ranges with `nl` and `sed` to verify the map scripts now appear in the head and the bottom-of-body block was removed, and the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3da5c3754832f8f82eb2d73f590fa)