### PR TITLE
Lazy-load full reports for browse search and map filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1041,6 +1041,8 @@
     let allTotalCount = 0;   // total number of reports (from paginated API)
     let stateCounts = {};
     let countryCounts = {};
+    let fullReportsList = [];
+    let fullListLoaded = false;
 
 
     // --- ADDED: submitter_uuid management (critical fix) ---
@@ -1164,6 +1166,25 @@
           created_at: sanitizeReportText(report && report.created_at, 64),
         };
       });
+    }
+
+    async function ensureFullListLoaded() {
+      if (fullListLoaded && fullReportsList.length) {
+        return true;
+      }
+      try {
+        const response = await fetch('https://api.namehim.app/filtered-reports');
+        if (!response.ok) throw new Error(`Worker returned ${response.status}`);
+        const reports = await response.json();
+        fullReportsList = sanitizeFetchedReports(reports);
+        fullListLoaded = true;
+        return true;
+      } catch (error) {
+        console.error('Failed to load full reports list:', error);
+        browseMessage.textContent = 'Unable to load full data for search. Please try again.';
+        browseMessage.className = 'message error';
+        return false;
+      }
     }
 
     function toTitleCase(value) {
@@ -1340,38 +1361,47 @@
 
     window.clearBrowseLocationDropdownValues = clearBrowseLocationDropdownValues;
 
-function filterReportsByState(stateFullName) {
+async function filterReportsByState(stateFullName) {
+  const loaded = await ensureFullListLoaded();
+  if (!loaded) return;
+
+  const filtered = fullReportsList.filter((r) => r.state === stateFullName);
+  allReports = filtered;
+  window.allReports = allReports;
+  allTotalCount = filtered.length;
+  renderPagedReports(allReports, 1);
+
+  browseMessage.textContent = filtered.length
+    ? `Showing ${filtered.length} report(s) for ${stateFullName}.`
+    : `No reports found for ${stateFullName}.`;
+  browseMessage.className = 'message';
+
   const searchInput = document.getElementById('report-search');
-  if (searchInput) {
-    searchInput.value = stateFullName;
-  }
-
-  const selectedCountry = String((browseCountrySelect && browseCountrySelect.value) || '').trim();
-  if (selectedCountry && !isUnitedStatesCountryValue(selectedCountry)) {
-    setCountryDropdownValue('');
-    if (typeof window.clearSelectedWorldCountry === 'function') {
-      window.clearSelectedWorldCountry();
-    }
-  }
-
+  if (searchInput) searchInput.value = stateFullName;
+  setCountryDropdownValue('');
+  setStateDropdownValue(stateFullName);
   updateBrowseLocationFiltersUI();
-
-  // Reuse your existing search filter
-  if (typeof applySearchFilter === 'function') {
-    applySearchFilter();
-  } else {
-    // Fallback
-    const filtered = allReports.filter(r => r.state === stateFullName);
-    renderPagedReports(filtered, 1);
-    const browseMsg = document.getElementById('browse-message');
-    if (browseMsg) browseMsg.textContent = filtered.length ? `Showing ${filtered.length} of ${allReports.length} report(s), ${REPORTS_PER_PAGE} per page.` : 'No reports found.';
-  }
+  if (getReportIdFromUrl()) clearSingleReportHash();
 }
 
-    function filterReportsByCountry(countryName) {
+    async function filterReportsByCountry(countryName) {
       if (!countryName) {
         return;
       }
+
+      const loaded = await ensureFullListLoaded();
+      if (!loaded) return;
+
+      const filtered = fullReportsList.filter((r) => r.country === countryName);
+      allReports = filtered;
+      window.allReports = allReports;
+      allTotalCount = filtered.length;
+      renderPagedReports(allReports, 1);
+
+      browseMessage.textContent = filtered.length
+        ? `Showing ${filtered.length} report(s) for ${countryName}.`
+        : `No reports found for ${countryName}.`;
+      browseMessage.className = 'message';
 
       setCountryDropdownValue(countryName);
       setStateDropdownValue('');
@@ -1379,7 +1409,7 @@ function filterReportsByState(stateFullName) {
       if (typeof window.clearSelectedMapState === 'function') {
         window.clearSelectedMapState();
       }
-      applySearchFilter();
+      if (getReportIdFromUrl()) clearSingleReportHash();
     }
 
     window.filterReportsByCountry = filterReportsByCountry;
@@ -1919,11 +1949,12 @@ function addStoryTimestamp() {
     }
 
 
-    function applySearchFilter(options = {}) {
+    async function applySearchFilter(options = {}) {
       const preservePage = Boolean(options.preservePage);
       const reportId = getReportIdFromUrl();
       if (getCurrentRoute() === '#/browse' && reportId) {
-        const matched = allReports.find((report) => String(report.id) === reportId);
+        const sourceReports = fullListLoaded ? fullReportsList : allReports;
+        const matched = sourceReports.find((report) => String(report.id) === reportId);
         if (matched) {
           showSingleReport(matched);
         } else {
@@ -1936,7 +1967,19 @@ function addStoryTimestamp() {
       const selectedCountry = String((browseCountrySelect && browseCountrySelect.value) || '').trim().toLowerCase();
       const selectedState = String((browseStateSelect && browseStateSelect.value) || '').trim().toLowerCase();
 
-      const filtered = allReports.filter((report) => {
+      if (!query && !selectedCountry && !selectedState) {
+        renderPagedReports(allReports, preservePage ? currentPage : 1);
+        browseMessage.textContent = allReports.length
+          ? `Loaded ${allTotalCount} report(s) total. Showing up to ${REPORTS_PER_PAGE} per page.`
+          : 'No reports yet. Be the first to submit.';
+        browseMessage.className = 'message';
+        return;
+      }
+
+      const loaded = await ensureFullListLoaded();
+      if (!loaded) return;
+
+      const filtered = fullReportsList.filter((report) => {
         const blob = [report.name, report.city, report.state, report.country]
           .map((item) => String(item || '').toLowerCase())
           .join(' ');
@@ -1950,18 +1993,12 @@ function addStoryTimestamp() {
         return matchesQuery && matchesCountry && matchesState;
       });
 
-      if (!query && !selectedCountry && !selectedState) {
-        renderPagedReports(filtered, preservePage ? currentPage : 1);
-        browseMessage.textContent = filtered.length
-          ? 'Loaded ' + allReports.length + ' report(s). Showing up to ' + REPORTS_PER_PAGE + ' per page.'
-          : 'No reports yet. Be the first to submit.';
-        browseMessage.className = 'message';
-        return;
-      }
-
-      renderPagedReports(filtered, preservePage ? currentPage : 1);
+      allReports = filtered;
+      window.allReports = allReports;
+      allTotalCount = filtered.length;
+      renderPagedReports(allReports, 1);
       browseMessage.textContent = filtered.length
-        ? 'Showing ' + filtered.length + ' of ' + allReports.length + ' report(s), ' + REPORTS_PER_PAGE + ' per page.'
+        ? `Showing ${filtered.length} matching report(s) (out of ${fullReportsList.length} total).`
         : 'No matching reports found.';
       browseMessage.className = 'message';
     }
@@ -1984,7 +2021,7 @@ function addStoryTimestamp() {
     }
 
     // Store only the current page of reports
-    allReports = data.reports;
+    allReports = sanitizeFetchedReports(data.reports);
     window.allReports = allReports;
     allTotalCount = data.total;
     hasLoadedReports = true;
@@ -2531,7 +2568,7 @@ async function loadMapStats() {
       reportSearch.addEventListener('input', applySearchFilter);
       bindNoNumberFields();
       bindFieldLengthLimits();
-      clearSearch.addEventListener('click', function clearSearchInput() {
+      clearSearch.addEventListener('click', async function clearSearchInput() {
         reportSearch.value = '';
         if (browseCountrySelect) {
           browseCountrySelect.value = '';
@@ -2548,7 +2585,7 @@ async function loadMapStats() {
           clearSingleReportHash();
           return;
         }
-        applySearchFilter();
+        await loadReports(1);
       });
       if (backToAllReportsBtn) {
         backToAllReportsBtn.addEventListener('click', function onBackToAllReportsClick() {


### PR DESCRIPTION
### Motivation
- Keep initial browse load fast by using the paginated endpoint and only fetch the full reports list when the user performs a search or uses location filters. 
- Ensure search, country/state dropdowns and map clicks operate across the entire dataset (not just the current page). 
- Provide a single cached full-dataset load so subsequent filtering is fast and consistent. 
- Reset the UI back to the paginated mode when the user clears the search.

### Description
- Added `fullReportsList` and `fullListLoaded` globals and implemented `ensureFullListLoaded()` to lazily fetch and sanitize `/filtered-reports` only when needed. 
- Converted `applySearchFilter` into an `async` function that preserves the fast path when no filters are active and otherwise loads the full list and filters `fullReportsList` by query/country/state. 
- Reworked `filterReportsByCountry` and `filterReportsByState` to async implementations that use the full cached list and update `allReports`, pagination, and UI messaging. 
- Sanitized rows returned by the paginated endpoint via `sanitizeFetchedReports` and changed the clear-search handler to call `loadReports(1)` to restore paginated mode.

### Testing
- No automated tests were executed because this repository does not include a configured automated test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3de65afe4832fa1ffda6084039195)