### PR TITLE
Add explanatory note on Browse page clarifying map report counts

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,6 +400,15 @@
       flex: 1;
     }
 
+    .map-count-note {
+      font-size: 0.75rem;
+      color: #facc15;
+      text-align: center;
+      line-height: 1.3;
+      flex: 1.6;
+      margin: 0;
+    }
+
     .map-toggle-btn {
       min-width: 0;
       flex: 1;
@@ -599,6 +608,7 @@
           <div class="map-toggle-wrap">
             <button id="toggle-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="map">Show US Map</button>
           </div>
+          <p class="map-count-note">Map totals may currently appear lower than the actual report count. Click any state or country on the map to view all reports for that location, which may show a higher total.</p>
           <div class="map-toggle-wrap">
             <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
           </div>


### PR DESCRIPTION
### Motivation
- Clarify to users that interactive map totals may show lower numbers than the full report counts and instruct them to click a state or country to view the complete (potentially higher) total.

### Description
- Inserted a short, professional explanatory paragraph between the `Show US Map` and `Show World Map` buttons in `index.html` using the `.map-count-note` class.
- Added compact styling for `.map-count-note` to make the text small, yellow, and visually balanced alongside the map toggle buttons.

### Testing
- No automated tests were run for this content and styling update. Please review visually in the Browse page to confirm appearance and placement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f429727120832fac3cd23a262cc99f)