### PR TITLE
Adjust browse page map toggle button layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,9 +406,16 @@
 
     .map-toggle-row {
       display: flex;
+      flex-direction: column;
+      align-items: flex-start;
       gap: 0.5rem;
-      align-items: center;
       margin-bottom: 0.65rem;
+    }
+
+    .map-toggle-buttons {
+      display: flex;
+      gap: 0.5rem;
+      width: 100%;
     }
 
     .map-toggle-row .map-toggle-wrap {
@@ -421,8 +428,8 @@
       color: #facc15;
       text-align: center;
       line-height: 1.3;
-      flex: 1.6;
       margin: 0;
+      width: 100%;
     }
 
     .map-toggle-btn {
@@ -621,13 +628,15 @@
           <span>(full list below).</span>
         </p>
         <div class="map-toggle-row">
-          <div class="map-toggle-wrap">
-            <button id="toggle-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="map">Show US Map</button>
+          <div class="map-toggle-buttons">
+            <div class="map-toggle-wrap">
+              <button id="toggle-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="map">Show US Map</button>
+            </div>
+            <div class="map-toggle-wrap">
+              <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
+            </div>
           </div>
           <p class="map-count-note">Map totals may currently appear lower than the actual report count. Click any state or country on the map to view all reports for that location, which may show a higher total.</p>
-          <div class="map-toggle-wrap">
-            <button id="toggle-world-map-btn" class="map-toggle-btn" type="button" aria-expanded="false" aria-controls="world-map">Show World Map</button>
-          </div>
         </div>
         <div id="map"></div>
         <div id="world-map"></div>


### PR DESCRIPTION
### Motivation
- Improve the browse page layout so the two map toggle actions are visually grouped together and the explanatory note remains after them.
- Provide a small, consistent gap between the `Show US Map` and `Show World Map` buttons so they appear adjacent but not touching.

### Description
- Moved the `Show World Map` button into a new adjacent button row next to the `Show US Map` button in `index.html` so both toggles sit side-by-side under the country/state selectors.
- Added a `.map-toggle-buttons` flex container and updated `.map-toggle-row` to stack the button row above the note by switching to a column layout and aligning items to the start.
- Adjusted `.map-count-note` to span the full width beneath the buttons and removed the previous `flex: 1.6` behavior to preserve the note placement.
- No JavaScript logic was changed; only HTML structure and CSS rules in `index.html` were modified.

### Testing
- Ran `git -C /workspace/namehim diff -- index.html` to inspect the change, which showed the intended HTML/CSS modifications and succeeded.
- Ran `git -C /workspace/namehim add index.html && git -C /workspace/namehim commit -m "Adjust browse map toggle button layout"` to record the change, which completed successfully.
- No automated unit or integration tests were run because this is a layout-only HTML/CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42dda4b20832fb8cab406409204cd)