### PR TITLE
Update resources search prompt to 'Search for your country'

### DIFF
--- a/resources.html
+++ b/resources.html
@@ -181,8 +181,8 @@
     <div class="container resources-wrap">
       <p class="intro">If you are in immediate danger, contact your local emergency number right away. The resources below may help with domestic violence, sexual assault, crisis support, and victim services. (Countries with most site visitors shown first, adding more soon)</p>
       <div class="resource-search">
-        <label for="resource-search-input">Search resources by country, hotline, keyword, or phone number</label>
-        <input id="resource-search-input" type="search" placeholder="Try: United States, RAINN, 116 016, emergency…" />
+        <label for="resource-search-input">Search for your country</label>
+        <input id="resource-search-input" type="search" placeholder="Search for your country" />
         <p id="resource-results-count" class="result-count" aria-live="polite"></p>
       </div>
       <div id="resource-grid" class="grid">


### PR DESCRIPTION
### Motivation
- Clarify the resources page search UI so users understand they should search by country only and remove example prompts that suggested other query types.

### Description
- Changed the label text to `Search for your country` and updated the search input `placeholder` to `Search for your country` in `resources.html` (replacing the previous guidance and example placeholder).

### Testing
- No automated tests were run for this content-only copy change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f48c249190832f960af3e2d1c7239d)