### PR TITLE
Allow international characters in submit location fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,7 @@
         return '';
       }
       return normalized
-        .replace(/[^A-Za-z\s]+/g, '')
+        .replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')
         .replace(/\s+/g, ' ')
         .trim();
     }
@@ -1799,7 +1799,7 @@ function addStoryTimestamp() {
       if (!normalized) {
         return false;
       }
-      return !/^[A-Za-z\s]+$/.test(normalized);
+      return !/^[\p{L}\p{M}\s'\-.]+$/u.test(normalized);
     }
 
     function preventInvalidCharsForField(fieldElement) {
@@ -1810,7 +1810,7 @@ function addStoryTimestamp() {
       fieldElement.dataset.lettersOnlyBound = 'true';
       fieldElement.addEventListener('input', () => {
         const cleanedValue = fieldElement.value
-          .replace(/[^A-Za-z\s]+/g, '')
+          .replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')
           .replace(/\s+/g, ' ')
           .trimStart();
         if (cleanedValue !== fieldElement.value) {
@@ -2412,7 +2412,7 @@ async function loadMapStats() {
         hasInvalidLettersOnlyChars(payload.city) ||
         (shouldValidateStateInput && hasInvalidLettersOnlyChars(payload.state))
       ) {
-        submitMessage.textContent = '* Name and Location can only contain English letters (A-Z).';
+        submitMessage.textContent = '* Name and Location can only contain letters in any language, spaces, apostrophes, periods, and hyphens.';
         submitMessage.className = 'message error';
         return;
       }


### PR DESCRIPTION
### Motivation
- The site currently strips non-ASCII letters from user-submitted Name/City/State fields, which prevents accented and non-English names from being entered and harms international usability.
- The change aims to accept letters from other languages (including diacritics) without altering other sanitisation rules or breaking existing submission flows.

### Description
- Updated `sanitizeLettersOnlyText` in `index.html` to use a Unicode-aware regex, changing the replacement to `replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')` (actual code uses `\p{L}`/`\p{M}` classes) so letters and combining marks in any language are preserved while disallowing other symbols.  
- Updated `hasInvalidLettersOnlyChars` validation to use a Unicode-aware test (`/^[\p{L}\p{M}\s'\-.]+$/u`) so submit-time validation accepts multilingual names and locations.  
- Updated live input filtering in `preventInvalidCharsForField` to mirror the new sanitisation (replacement uses `replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')`) to avoid surprising user edits while typing.  
- Reworded the user-facing validation message to reflect support for letters in any language and allowed punctuation, and limited the change to `index.html` only.

### Testing
- No automated test suite is defined in this repository, so no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4958ca21c832f854a7c6936a492bf)