### PR TITLE
Allow Unicode letters and common punctuation in name/location fields; sync client and DB validation and reset CAPTCHA on errors

### DIFF
--- a/index.html
+++ b/index.html
@@ -1125,7 +1125,7 @@
         return '';
       }
       return normalized
-        .replace(/[^A-Za-z\s]+/g, '')
+        .replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')
         .replace(/\s+/g, ' ')
         .trim();
     }
@@ -1799,7 +1799,7 @@ function addStoryTimestamp() {
       if (!normalized) {
         return false;
       }
-      return !/^[A-Za-z\s]+$/.test(normalized);
+      return !/^[\p{L}\p{M}\s'\-.]+$/u.test(normalized);
     }
 
     function preventInvalidCharsForField(fieldElement) {
@@ -1810,7 +1810,7 @@ function addStoryTimestamp() {
       fieldElement.dataset.lettersOnlyBound = 'true';
       fieldElement.addEventListener('input', () => {
         const cleanedValue = fieldElement.value
-          .replace(/[^A-Za-z\s]+/g, '')
+          .replace(/[^\p{L}\p{M}\s'\-.]+/gu, '')
           .replace(/\s+/g, ' ')
           .trimStart();
         if (cleanedValue !== fieldElement.value) {
@@ -2412,7 +2412,7 @@ async function loadMapStats() {
         hasInvalidLettersOnlyChars(payload.city) ||
         (shouldValidateStateInput && hasInvalidLettersOnlyChars(payload.state))
       ) {
-        submitMessage.textContent = '* Name and Location can only contain English letters (A-Z).';
+        submitMessage.textContent = '* Name and Location can only contain letters in any language, spaces, apostrophes, periods, and hyphens.';
         submitMessage.className = 'message error';
         return;
       }
@@ -2466,6 +2466,7 @@ async function loadMapStats() {
         window.location.hash = '#/browse';
       } catch (error) {
         console.error('Submission error:', error);
+        resetTurnstileWidget();
         submitMessage.textContent = error.message;
         submitMessage.className = 'message error';
       } finally {

--- a/supabase.sql
+++ b/supabase.sql
@@ -27,19 +27,19 @@ alter table public.reports
   add constraint reports_name_check
     check (char_length(btrim(name)) between 1 and 20 and octet_length(name) <= 80),
   add constraint reports_name_letters_check
-    check (btrim(name) ~ '^[A-Za-z ]+$'),
+    check (btrim(name) ~ '^[[:alpha:][:space:]''.-]+$'),
   add constraint reports_city_check
     check (char_length(btrim(city)) between 1 and 20 and octet_length(city) <= 80),
   add constraint reports_city_letters_check
-    check (btrim(city) ~ '^[A-Za-z ]+$'),
+    check (btrim(city) ~ '^[[:alpha:][:space:]''.-]+$'),
   add constraint reports_state_check
     check (state is null or (char_length(btrim(state)) between 1 and 20 and octet_length(state) <= 80)),
   add constraint reports_state_letters_check
-    check (state is null or btrim(state) ~ '^[A-Za-z ]+$'),
+    check (state is null or btrim(state) ~ '^[[:alpha:][:space:]''.-]+$'),
   add constraint reports_country_check
     check (char_length(btrim(country)) between 1 and 20 and octet_length(country) <= 80),
   add constraint reports_country_letters_check
-    check (btrim(country) ~ '^[A-Za-z ]+$'),
+    check (btrim(country) ~ '^[[:alpha:][:space:]''.-]+$'),
   add constraint reports_submitter_uuid_check
     check (char_length(btrim(submitter_uuid)) between 16 and 100);
 
@@ -86,16 +86,16 @@ for insert
 to anon, authenticated
 with check (
   char_length(btrim(name)) between 1 and 20
-  and btrim(name) ~ '^[A-Za-z ]+$'
+  and btrim(name) ~ '^[[:alpha:][:space:]''.-]+$'
   and octet_length(name) <= 80
   and char_length(btrim(city)) between 1 and 20
-  and btrim(city) ~ '^[A-Za-z ]+$'
+  and btrim(city) ~ '^[[:alpha:][:space:]''.-]+$'
   and octet_length(city) <= 80
   and (state is null or char_length(btrim(state)) between 1 and 20)
-  and (state is null or btrim(state) ~ '^[A-Za-z ]+$')
+  and (state is null or btrim(state) ~ '^[[:alpha:][:space:]''.-]+$')
   and (state is null or octet_length(state) <= 80)
   and char_length(btrim(country)) between 1 and 20
-  and btrim(country) ~ '^[A-Za-z ]+$'
+  and btrim(country) ~ '^[[:alpha:][:space:]''.-]+$'
   and octet_length(country) <= 80
   and char_length(btrim(submitter_uuid)) between 16 and 100
   and array_length(categories, 1) between 1 and 8


### PR DESCRIPTION
### Motivation
- Allow names and locations to include letters from any language as well as common characters like apostrophes, periods, and hyphens instead of restricting to ASCII A-Z only. 
- Keep client-side sanitization and validation rules consistent with server-side/Postgres constraints. 
- Ensure the Turnstile widget is reset on submission failures to avoid leaving the CAPTCHA in a stale state.

### Description
- Updated client-side sanitization and input-limiting functions by replacing ASCII-only regexes with Unicode-aware patterns using `\p{L}` and `\p{M}` and allowing spaces, apostrophes, periods, and hyphens in `sanitizeLettersOnlyText`, `hasInvalidLettersOnlyChars`, and the `input` handler in `preventInvalidCharsForField` (using `u`/`gu` flags). 
- Adjusted the user-facing validation message to reflect the new allowed character set. 
- Updated the Postgres constraints in `supabase.sql` to use POSIX character classes and allow the same characters via `btrim(...) ~ '^[[:alpha:][:space:]''.-]+$'` in checks and in the `with check` insert policy. 
- Added a call to `resetTurnstileWidget()` in the submit handler `catch` block so the CAPTCHA is reset when a submission error occurs.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f4958ca21c832f854a7c6936a492bf)