### PR TITLE
Fix map tooltip counts to use aggregated stats with paginated reports

### DIFF
--- a/index.html
+++ b/index.html
@@ -1078,6 +1078,8 @@
     let allTotalCount = 0;   // total number of reports (from paginated API)
     let stateCounts = {};
     let countryCounts = {};
+    window.stateCounts = stateCounts;
+    window.countryCounts = countryCounts;
     let fullReportsList = [];
     let fullListLoaded = false;
 
@@ -2112,6 +2114,8 @@ async function loadMapStats() {
     const data = await response.json();
     stateCounts = data && data.stateCounts && typeof data.stateCounts === 'object' ? data.stateCounts : {};
     countryCounts = data && data.countryCounts && typeof data.countryCounts === 'object' ? data.countryCounts : {};
+    window.stateCounts = stateCounts;
+    window.countryCounts = countryCounts;
     updateUSMapWithCounts();
     updateWorldMapWithCounts();
   } catch (e) {

--- a/usmap.js
+++ b/usmap.js
@@ -92,6 +92,11 @@ var simplemaps_usmap_mapinfo={map_name:'us',initial_view:{x:-20,y:-10,x2:980,y2:
   }
 
   function getReportCount(stateName) {
+    var counts = window.stateCounts && typeof window.stateCounts === "object" ? window.stateCounts : null;
+    if (counts && Object.prototype.hasOwnProperty.call(counts, stateName)) {
+      return Number(counts[stateName]) || 0;
+    }
+
     var reports = Array.isArray(window.allReports) ? window.allReports : [];
     var count = 0;
     for (var i = 0; i < reports.length; i += 1) {

--- a/worldmap.js
+++ b/worldmap.js
@@ -130,11 +130,22 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
   }
 
   function getCountryReportCount(countryName) {
-    var reports = Array.isArray(window.allReports) ? window.allReports : [];
+    var counts = window.countryCounts && typeof window.countryCounts === "object" ? window.countryCounts : null;
     var target = normalizeCountryForCount(countryName);
     var count = 0;
+    var reports;
     var i;
 
+    if (counts) {
+      Object.keys(counts).forEach(function (key) {
+        if (normalizeCountryForCount(key) === target) {
+          count += Number(counts[key]) || 0;
+        }
+      });
+      return count;
+    }
+
+    reports = Array.isArray(window.allReports) ? window.allReports : [];
     for (i = 0; i < reports.length; i += 1) {
       if (normalizeCountryForCount(reports[i] && reports[i].country) === target) {
         count += 1;
@@ -146,6 +157,7 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
 
   function getRegionReportCount(regionId) {
     var reports = Array.isArray(window.allReports) ? window.allReports : [];
+    var counts = window.countryCounts && typeof window.countryCounts === "object" ? window.countryCounts : null;
     var mapdata = window.simplemaps_worldmap_mapdata || {};
     var regions = mapdata.regions || {};
     var states = (regions[regionId] && regions[regionId].states) || [];
@@ -160,6 +172,15 @@ var simplemaps_worldmap_mapinfo={  map_name: "world",  initial_view: {    x: 0, 
       if (countrySpecific[countryId] && countrySpecific[countryId].name) {
         countryLookup[normalizeCountryForCount(countrySpecific[countryId].name)] = true;
       }
+    }
+
+    if (counts) {
+      Object.keys(counts).forEach(function (key) {
+        if (countryLookup[normalizeCountryForCount(key)]) {
+          count += Number(counts[key]) || 0;
+        }
+      });
+      return count;
     }
 
     for (i = 0; i < reports.length; i += 1) {


### PR DESCRIPTION
### Motivation
- Pagination changed the frontend so `window.allReports` holds only the current page, which caused map tooltips to show counts capped at the page size instead of totals. 
- The maps should display totals from the full corpus (aggregated `/stats`) even when the report list is paginated.

### Description
- Expose aggregated counts by publishing `stateCounts` and `countryCounts` on `window` in `index.html` and keep them updated after `loadMapStats()` so map scripts can access full totals via `window.stateCounts`/`window.countryCounts`.
- Update US map counting in `usmap.js` (`getReportCount`) to prefer `window.stateCounts[stateName]` and fall back to `window.allReports` when aggregates are unavailable.
- Update world map counting in `worldmap.js` (`getCountryReportCount` and `getRegionReportCount`) to prefer `window.countryCounts` aggregation and fall back to `window.allReports` when needed.
- All changes preserve the existing fallback behavior and only switch to aggregated counts when available; modified files: `index.html`, `usmap.js`, `worldmap.js`.

### Testing
- Ran syntax checks with `node --check usmap.js`, `node --check worldmap.js`, and `node --check worker/index.js`, all of which succeeded. 
- Local code formatting and basic smoke checks passed and the change was committed as `Fix map tooltip counts to use aggregated stats with paginated reports`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f49ea6f6e0832f8968ed35021a6558)