### PR TITLE
Add user-submitted poster section to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -181,6 +181,37 @@
       color: #bfdbfe;
     }
 
+
+    .poster-section {
+      margin-top: 1.5rem;
+    }
+
+    .poster-viewer {
+      width: 100%;
+      min-height: 620px;
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+      background: #ffffff;
+      margin-top: 0.5rem;
+    }
+
+    .poster-download {
+      margin-top: 0.85rem;
+      display: inline-block;
+      padding: 0.6rem 0.95rem;
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      background: var(--panel-2);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .poster-download:hover {
+      background: #334155;
+      color: #ffffff;
+    }
+
     .support-buttons {
       margin-top: 0.9rem;
       display: flex;
@@ -334,6 +365,13 @@
             </div>
           </div>
         </section>
+
+        <section class="poster-section">
+          <h3>User submitted poster</h3>
+          <embed class="poster-viewer" src="NameHimPoster.pdf" type="application/pdf" />
+          <a class="poster-download" href="NameHimPoster.pdf" download>Download poster PDF</a>
+        </section>
+
         <section>
           <p>Contact: namehim.app@proton.me</p>
         </section>


### PR DESCRIPTION
### Motivation
- Surface a user-submitted poster on the About page so visitors can view and download it without leaving the site.
- Keep the presentation consistent with the existing site styling and layout.

### Description
- Updated `about.html` to add a new `User submitted poster` section near the bottom of the article. 
- Embedded `NameHimPoster.pdf` inline using an `<embed>` element and added a download link using the `download` attribute pointing to `NameHimPoster.pdf`.
- Added CSS rules in `about.html` for `.poster-section`, `.poster-viewer`, and `.poster-download` to match the existing design language.
- Changes were committed to the repository (file modified: `about.html`).

### Testing
- No automated test suite is configured for this static HTML update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f531c9e030832f90431538684c7a81)