### PR TITLE
Add embedded poster preview and download link to About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -181,6 +181,32 @@
       color: #bfdbfe;
     }
 
+
+    .poster-frame {
+      width: 100%;
+      height: 900px;
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+      margin-top: 0.5rem;
+    }
+
+    .poster-download {
+      margin-top: 0.85rem;
+      display: inline-block;
+      padding: 0.6rem 0.95rem;
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      background: var(--panel-2);
+      color: var(--text);
+      text-decoration: none;
+      font-weight: 600;
+    }
+
+    .poster-download:hover {
+      background: #334155;
+      color: #ffffff;
+    }
+
     .support-buttons {
       margin-top: 0.9rem;
       display: flex;
@@ -334,6 +360,13 @@
             </div>
           </div>
         </section>
+
+        <section>
+          <h3>User submitted poster</h3>
+          <iframe class="poster-frame" src="NameHimPoster.pdf" title="User submitted poster PDF"></iframe>
+          <a class="poster-download" href="NameHimPoster.pdf" download>Download poster PDF</a>
+        </section>
+
         <section>
           <p>Contact: namehim.app@proton.me</p>
         </section>


### PR DESCRIPTION
### Motivation
- Provide a way for visitors to preview and download a user-submitted poster directly from the About page.
- Improve layout and styling for embedded poster assets so they integrate with the existing site UI.

### Description
- Added new CSS rules in `about.html` for `.poster-frame` and `.poster-download` to control the iframe size, borders, and download button styling.
- Inserted a new `section` into `about.html` that embeds `NameHimPoster.pdf` using an `<iframe class="poster-frame">` and exposes a download link with `class="poster-download"`.
- Placed the new poster section below the support buttons and above contact/admin log content to maintain page flow.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f531c9e030832f90431538684c7a81)