### PR TITLE
Reorder About page sections so User Submitted poster is last

### DIFF
--- a/about.html
+++ b/about.html
@@ -364,17 +364,16 @@
         </section>
 
         <section>
-          <h3>User submitted poster</h3>
-          <img class="poster-image" src="NameHimPoster-1.png" alt="User submitted NameHim poster" />
-          <a class="poster-download" href="NameHimPoster.pdf" download>Download poster PDF</a>
-        </section>
-
-        <section>
           <p>Contact: namehim.app@proton.me</p>
         </section>
         <section>
           <h3>Admin Log</h3>
           <p><strong>2:00 a.m. April 27, 2026 (PDT):</strong> The site suffered a very intelligent malicious attack, but after many hours of problem solving and updating the site and the database, it has been fixed and should stop this from happening in the future. In this process, there may have been an accidental deletion of some entries, so if you submitted your entry around the time the site had between 18,000 and 21,000 reports, please check if your submission is still there. If it is not, feel free to submit again.</p>
+        </section>
+        <section>
+          <h3>User submitted poster</h3>
+          <img class="poster-image" src="NameHimPoster-1.png" alt="User submitted NameHim poster" />
+          <a class="poster-download" href="NameHimPoster.pdf" download>Download poster PDF</a>
         </section>
       </article>
     </div>


### PR DESCRIPTION
### Motivation
- Make the About page layout put the `Contact` and `Admin Log` sections before the poster so the `User submitted poster` appears as the final section on the page.

### Description
- Moved the `User submitted poster` section in `about.html` to follow the `Contact` and `Admin Log` sections so it is now the last section in the article.

### Testing
- Verified the updated section order with `nl -ba about.html | sed -n '350,395p'` and committed the change with `git add` and `git commit` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5420c3d58832fa46c1a1f7531596e)