### PR TITLE
Fix browse shared report routing after data load

### DIFF
--- a/index.html
+++ b/index.html
@@ -2162,6 +2162,7 @@ function addStoryTimestamp() {
 
     browseMessage.textContent = `Loaded ${allReports.length} report(s) (page ${data.page} of ${Math.ceil(allTotalCount / limit)}).`;
     browseMessage.className = 'message';
+    updateBrowseViewFromRoute({ preserveBrowsePage: true });
 
   } catch (error) {
     console.error('Pagination failed, falling back to full fetch:', error);
@@ -2189,6 +2190,7 @@ async function loadReportsFull() {
     renderPagedReports(allReports, 1);
     browseMessage.textContent = `Loaded ${allReports.length} report(s).`;
     browseMessage.className = 'message';
+    updateBrowseViewFromRoute({ preserveBrowsePage: true });
   } catch (error) {
     console.error('Failed to load reports:', error);
     browseMessage.textContent = 'Unable to load reports right now. Please try again in a moment.';


### PR DESCRIPTION
### Motivation
- Shared browse links like `#/browse?report=<id>` were parsed before report data finished loading, and `updateBrowseViewFromRoute()` exits early when `hasLoadedReports` is false.  
- Because route handling was not re-run after the reports finished loading, shared links landed on the standard browse list instead of the intended single-report view.  

### Description
- After successfully fetching and rendering reports in `loadReports`, call `updateBrowseViewFromRoute({ preserveBrowsePage: true })` so the app re-evaluates the hash and opens a shared report if present.  
- Apply the same `updateBrowseViewFromRoute({ preserveBrowsePage: true })` call in the fallback `loadReportsFull` flow to keep paginated and full-fetch paths consistent.  
- Changes are limited to `index.html` and only affect post-load route synchronization for browse shared links.  

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5c4c647b4832f91fdc302fb386df9)