### PR TITLE
Move community post category pill to top-right

### DIFF
--- a/index.html
+++ b/index.html
@@ -586,6 +586,20 @@
   border-radius: 0.7rem;
   padding: 1rem;
 }
+.story-card-header {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 0.65rem;
+}
+.story-category {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 0.28rem 0.6rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
 .story-card h4 {
   margin: 0 0 0.5rem 0;
   color: var(--accent);
@@ -2307,9 +2321,10 @@ async function loadMapStats() {
       else if (categoryValue === 'Call to Action') categoryClass = 'story-category-calltoaction';
       else if (categoryValue === 'Question / Discussion') categoryClass = 'story-category-question';
       const categoryHtml = `<span class="story-category ${categoryClass}">${escapeHTML(categoryValue)}</span>`;
-      const titleHtml = story.title ? `<h4>${categoryHtml} ${escapeHTML(story.title)}</h4>` : `<h4>${categoryHtml}</h4>`;
+      const titleHtml = story.title ? `<h4>${escapeHTML(story.title)}</h4>` : '';
       return `
       <div class="story-card">
+        <div class="story-card-header">${categoryHtml}</div>
         ${titleHtml}
         <p>${escapeHTML(story.content)}</p>
         <div class="story-meta">— Anonymous, ${submittedAt}</div>


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy and spacing of community story cards by moving the category label out of the inline title area into a dedicated top-right position so it no longer hugs the title or card edges.

### Description
- Added a `.story-card-header` container and `.story-category` styling to position the category pill in the card header with compact padding, rounded corners, and stronger weight for a polished look.
- Updated `getStoryCardMarkup` to stop embedding the category inside the `<h4>` title and instead render `categoryHtml` inside a top-right header row and render the title independently as `titleHtml`.
- Kept existing category-to-class mapping (`story-category-*`) and reused those variants for color consistency.

### Testing
- Ran static checks including `rg -n "story-card-header|const titleHtml|story-category \{" index.html` which found the new symbols and succeeded. 
- Reviewed the change with `git diff -- index.html` and created a commit which succeeded. 
- No automated UI or visual regression tests were run for this HTML/CSS-only layout change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7b79aeaa0832fabd2c03caada2c35)