### PR TITLE
Align community story titles with category pills

### DIFF
--- a/index.html
+++ b/index.html
@@ -588,8 +588,16 @@
 }
 .story-card-header {
   display: flex;
-  justify-content: flex-end;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
   margin: 0 0 0.65rem;
+}
+.story-card-title {
+  margin: 0;
+  color: var(--accent);
+  flex: 1;
+  min-width: 0;
 }
 .story-category {
   display: inline-flex;
@@ -599,10 +607,6 @@
   font-size: 0.75rem;
   font-weight: 700;
   letter-spacing: 0.01em;
-}
-.story-card h4 {
-  margin: 0 0 0.5rem 0;
-  color: var(--accent);
 }
 .story-actions {
   margin-top: 0.75rem;
@@ -2321,11 +2325,10 @@ async function loadMapStats() {
       else if (categoryValue === 'Call to Action') categoryClass = 'story-category-calltoaction';
       else if (categoryValue === 'Question / Discussion') categoryClass = 'story-category-question';
       const categoryHtml = `<span class="story-category ${categoryClass}">${escapeHTML(categoryValue)}</span>`;
-      const titleHtml = story.title ? `<h4>${escapeHTML(story.title)}</h4>` : '';
+      const titleHtml = story.title ? `<h4 class="story-card-title">${escapeHTML(story.title)}</h4>` : '';
       return `
       <div class="story-card">
-        <div class="story-card-header">${categoryHtml}</div>
-        ${titleHtml}
+        <div class="story-card-header">${titleHtml}${categoryHtml}</div>
         <p>${escapeHTML(story.content)}</p>
         <div class="story-meta">— Anonymous, ${submittedAt}</div>
         <div class="story-actions">


### PR DESCRIPTION
### Motivation
- Restore horizontal alignment of the community post title with the pill-shaped category label so titles sit on the same top row as the category pill.
- Allow long titles to wrap to a second line instead of pushing or overlapping the category pill.

### Description
- Adjusted `.story-card-header` to `align-items: flex-start`, `justify-content: space-between`, and added a `gap` so the title and category pill share one row with spacing.
- Added a `.story-card-title` rule with `flex: 1` and `min-width: 0` so titles can truncate/wrap naturally without pushing the pill.
- Moved title markup inside the `.story-card-header` and applied the `story-card-title` class in `getStoryCardMarkup` so the title renders left of the category pill on the same line.

### Testing
- Verified the file changes with `git diff -- index.html` and inspected modified lines with `nl -ba index.html | sed -n` (succeeded).
- Staged and committed the change with `git add index.html && git commit -m "Align community story title with category pill"` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7c459b840832fa82d7968d4e98286)