### PR TITLE
Default browse route to page 10 results

### DIFF
--- a/index.html
+++ b/index.html
@@ -1166,6 +1166,7 @@
     window.countryCounts = countryCounts;
     let fullReportsList = [];
     let fullListLoaded = false;
+    const DEFAULT_BROWSE_PAGE = 10;
 
 
     // --- ADDED: submitter_uuid management (critical fix) ---
@@ -1804,6 +1805,10 @@ async function filterReportsByState(stateFullName) {
   });
 
   updateBrowseViewFromRoute();
+
+  if (route === '#/browse' && !getReportIdFromUrl()) {
+    loadReports(DEFAULT_BROWSE_PAGE);
+  }
 
   if (route === '#/community') {
     updateCommunityViewFromRoute();
@@ -2803,7 +2808,6 @@ async function loadMapStats() {
       renderCategories();
       updateRateLimitUI();
       renderRoute();
-      loadReports(1);
       loadMapStats();
       setupReportActionHandler();
       startRealtimeUpdates();
@@ -2841,7 +2845,7 @@ async function loadMapStats() {
           clearSingleReportHash();
           return;
         }
-        await loadReports(1);
+        await loadReports(DEFAULT_BROWSE_PAGE);
       });
       if (backToAllReportsBtn) {
         backToAllReportsBtn.addEventListener('click', function onBackToAllReportsClick() {


### PR DESCRIPTION
### Motivation
- Change the default browse landing so the app shows the 10th page of results on initial load/refresh/navigation instead of page 1 to avoid immediately exposing the first page of results while preserving all pagination controls.

### Description
- Added a `DEFAULT_BROWSE_PAGE` constant set to `10` and used it as the default target page.
- Updated `renderRoute()` to call `loadReports(DEFAULT_BROWSE_PAGE)` when the route is `#/browse` and there is no shared `report=` query parameter.
- Removed the explicit `loadReports(1)` startup call in `init()` so initial loading is driven by the route logic.
- Updated the clear-search handler to reload `DEFAULT_BROWSE_PAGE` instead of page `1` so clearing search keeps the same default behavior.

### Testing
- Verified the code changes with `rg`/searches to confirm `DEFAULT_BROWSE_PAGE` and updated `loadReports` calls were inserted and `loadReports(1)` was removed where intended.
- Ran `git diff -- index.html` to inspect the diff and `git commit` which completed successfully.
- No automated unit tests were present or executed for this change; the update was validated via the repository-level checks above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7dd581d70832f990f9163e51a4a50)