### PR TITLE
Restore browse pagination and preserve default page 10

### DIFF
--- a/index.html
+++ b/index.html
@@ -1159,6 +1159,7 @@
     let approvedStories = [];
     let hasLoadedReports = false;
     let allTotalCount = 0;   // total number of reports (from paginated API)
+    let currentBrowseServerPage = 1;
     let stateCounts = {};
     let countryCounts = {};
     const MAP_COUNTS_STORAGE_KEY = 'namehim_map_counts_v1';
@@ -2092,7 +2093,7 @@ function addStoryTimestamp() {
     function renderPagination(totalReports, page) {
       browsePagination.innerHTML = '';
       const totalPages = Math.ceil(totalReports / REPORTS_PER_PAGE);
-      const maxVisiblePageButtons = 5;
+      const maxVisiblePageButtons = 3;
 
       if (totalPages <= 1) {
         return;
@@ -2174,7 +2175,12 @@ function addStoryTimestamp() {
       const selectedState = normalizeStateForFiltering((browseStateSelect && browseStateSelect.value) || '');
 
       if (!query && !selectedCountry && !selectedState) {
-        renderPagedReports(allReports, preservePage ? currentPage : 1);
+        if (!fullListLoaded) {
+          renderReportRows(allReports);
+          renderPagination(allTotalCount, currentBrowseServerPage);
+        } else {
+          renderPagedReports(allReports, preservePage ? currentPage : 1);
+        }
         browseMessage.textContent = allReports.length
           ? `Loaded ${allTotalCount} report(s) total. Showing up to ${REPORTS_PER_PAGE} per page.`
           : 'No reports yet. Be the first to submit.';
@@ -2230,6 +2236,7 @@ function addStoryTimestamp() {
     allReports = sanitizeFetchedReports(data.reports);
     window.allReports = allReports;
     allTotalCount = data.total;
+    currentBrowseServerPage = Number(data.page) || 1;
     hasLoadedReports = true;
     ensureCountsCoverTotalReports();
 


### PR DESCRIPTION
### Motivation
- The browse pagination UI collapsed to a single page when the client re-paginated only the current 50-row chunk instead of honoring server-side pagination, hiding the First/Prev/Next/Last controls and page numbers.
- The app must continue to load the browse page on page `10` by default so moderators avoid showing new spammy entries to visitors.

### Description
- Added a `currentBrowseServerPage` variable to track which API page was loaded so the pager can highlight the correct active page after fetches by the paginated endpoint.
- Restored behavior in `applySearchFilter()` so when there are no local filters/searches the UI renders the server-side page and pagination via `renderReportRows()` and `renderPagination(allTotalCount, currentBrowseServerPage)` instead of client-side re-pagination of the current 50-row slice.
- Updated `loadReports()` to set `currentBrowseServerPage = Number(data.page) || 1` after a successful paginated fetch and kept `DEFAULT_BROWSE_PAGE = 10` as the default route load.
- Reduced the numbered page window to show `3` visible page-number buttons for a compact professional pager while retaining `First/Previous/Next/Last` and jump-to-end buttons.

### Testing
- Inspected and searched `index.html` with `rg` to find pagination-related code and verified the affected functions and constants were updated; these checks succeeded.
- Examined the modified source regions with `sed -n` and `nl -ba` to confirm `currentBrowseServerPage` is declared and used and that `renderPagination()` and `applySearchFilter()` changes are present; these inspections succeeded.
- Performed an automated in-place edit via a small `python` script to apply the changes and verified the updated sections appear as intended; the edit and verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7e2621500832fa1930b0de7ec67dc)