### PR TITLE
Fix browse pagination page normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -2094,13 +2094,16 @@ function addStoryTimestamp() {
       browsePagination.innerHTML = '';
       const totalPages = Math.ceil(totalReports / REPORTS_PER_PAGE);
       const maxVisiblePageButtons = 3;
+      const normalizedPage = Number.isFinite(Number(page))
+        ? Math.min(Math.max(Math.trunc(Number(page)), 1), Math.max(totalPages, 1))
+        : 1;
 
       if (totalPages <= 1) {
         return;
       }
 
-      const isAtFirstPage = page <= 1;
-      const isAtLastPage = page >= totalPages;
+      const isAtFirstPage = normalizedPage <= 1;
+      const isAtLastPage = normalizedPage >= totalPages;
       let paginationHTML = '';
 
       paginationHTML += '<button type="button" data-page-nav="first"' + (isAtFirstPage ? ' disabled' : '') + '>First</button>';
@@ -2111,7 +2114,7 @@ function addStoryTimestamp() {
 
       if (totalPages > maxVisiblePageButtons) {
         const halfWindow = Math.floor(maxVisiblePageButtons / 2);
-        startPage = Math.max(1, page - halfWindow);
+        startPage = Math.max(1, normalizedPage - halfWindow);
         endPage = startPage + maxVisiblePageButtons - 1;
 
         if (endPage > totalPages) {
@@ -2128,8 +2131,8 @@ function addStoryTimestamp() {
       }
 
       for (let pageNumber = startPage; pageNumber <= endPage; pageNumber += 1) {
-        const activeClass = pageNumber === page ? ' class="active"' : '';
-        const currentPageAttr = pageNumber === page ? ' aria-current="page"' : '';
+        const activeClass = pageNumber === normalizedPage ? ' class="active"' : '';
+        const currentPageAttr = pageNumber === normalizedPage ? ' aria-current="page"' : '';
         paginationHTML += '<button type="button" data-page="' + pageNumber + '"' + activeClass + currentPageAttr + '>' + pageNumber + '</button>';
       }
 


### PR DESCRIPTION
### Motivation
- The pagination UI could receive a `page` value from the server that is not a numeric integer (for example, a string), which prevented the active page button from being set and caused navigation (Next/Previous) to appear stuck for large result sets.

### Description
- Normalize the incoming `page` value in `renderPagination` to a bounded integer via a new `normalizedPage` computed value and fall back to `1` when invalid.
- Replace direct uses of `page` with `normalizedPage` for first/last disabled state, visible page-window calculation, and active/current page highlighting.
- Keep the rest of the pagination rendering logic intact so paged and full-list flows continue to operate as before.

### Testing
- Applied the automated patch script that updated `index.html` and it completed successfully.
- Verified the updated `renderPagination` block contents with `nl`/`sed` excerpts to confirm `normalizedPage` is present and used in comparisons, which succeeded. 
- Confirmed the pagination rendering now uses the normalized page variable in the file excerpt validation step, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b82bd3dc4832fadb1f6391d7131ce)