### PR TITLE
Remove header announcement and add baby arrival update on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -403,6 +403,7 @@
           <p>I am committed to keeping this site up, functional, and free. If you want to support that by helping with the costs of the site, or if there's any extra to help me and my family with our bills or other necessities so we can bring our child into a stable environment, it is greatly appreciated.</p>
           <p>(When things develop, such as the arrival of our baby or when we get into a more stable position, I will update this section to let you guys know.)</p>
           <p>Update (5/6/2026): Still waiting on our son to arrive and our car is still not in service but we are getting by one day at a time. I added two moderators to help get rid of the spam and retaliation reports and I them 20% each of any tips or donations that come in now, so thank you from the three of us anyone who chooses to support.</p>
+          <p>Update (5/18/2026): Our baby has arrived. Thank you to everyone who supported us during the pregnancy and while we were struggling with transportation and bills. Your support helped us keep this project online while welcoming our child.</p>
           <div class="support-buttons">
             <div>
               <script src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>

--- a/index.html
+++ b/index.html
@@ -644,7 +644,6 @@
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
         <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
-      <p class="header-status"> We now have a team of three moderators working every day to remove spam and retaliation reports. Still working on making everything completely functional. Please check the about page to see how you can support, and thank you to those who have supported so far.</p>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Remove the persistent yellow announcement/status text that appears in the main header so it no longer shows site-wide.
- Move the personal project update into the About page by adding a dated note that the baby has arrived and thanking supporters.

### Description
- Deleted the `<p class="header-status">…</p>` announcement paragraph from `index.html` so the header no longer contains the status message.
- Added a new paragraph `Update (5/18/2026): Our baby has arrived…` to the Financial Transparency and Optional Support section of `about.html` to record the personal update.
- No other content or layout changes were made to the pages.

### Testing
- Located the announcement and affected files with `rg --files` and `rg -n "header-status|team of three moderators|check the about page|Still waiting on our son" *.html`, which returned the expected hits and exited successfully.
- Reviewed the specific sections with `sed -n '630,670p' index.html` and `sed -n '380,460p' about.html` and with `nl -ba ... | sed -n '638,660p'` / `nl -ba ... | sed -n '398,414p'`, confirming the removal and insertion respectively; all commands succeeded.
- Created the PR body using the repo tooling (PR metadata generated) and verified the file diffs correspond to the described edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b896eb210832f8bff25e8cf5c2dff)