### PR TITLE
Add optional admin reply display to community stories

### DIFF
--- a/index.html
+++ b/index.html
@@ -618,6 +618,22 @@
   font-size: 0.8rem;
   color: var(--muted);
 }
+.admin-reply {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: rgba(96, 165, 250, 0.1);
+  border-left: 3px solid var(--accent);
+  border-radius: 0.25rem;
+  font-size: 0.9rem;
+}
+.admin-reply h5 {
+  margin: 0 0 0.5rem 0;
+  color: var(--accent);
+  font-size: 0.85rem;
+}
+.admin-reply p {
+  margin: 0;
+}
     
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
@@ -2340,10 +2356,18 @@ async function loadMapStats() {
       else if (categoryValue === 'Question / Discussion') categoryClass = 'story-category-question';
       const categoryHtml = `<span class="story-category ${categoryClass}">${escapeHTML(categoryValue)}</span>`;
       const titleHtml = story.title ? `<h4 class="story-card-title">${escapeHTML(story.title)}</h4>` : '';
+      const adminReply = String(story.admin_reply || '').trim();
+      const adminReplyHtml = adminReply
+        ? `<div class="admin-reply">
+          <h5>Admin Reply</h5>
+          <p>${escapeHTML(adminReply)}</p>
+        </div>`
+        : '';
       return `
       <div class="story-card">
         <div class="story-card-header">${titleHtml}${categoryHtml}</div>
         <p>${escapeHTML(story.content)}</p>
+        ${adminReplyHtml}
         <div class="story-meta">— Anonymous, ${submittedAt}</div>
         <div class="story-actions">
           <button type="button" class="story-share-btn" data-story-id="${escapeHTML(story.id || '')}">Share</button>
@@ -2405,7 +2429,7 @@ async function loadMapStats() {
       storiesContainer.innerHTML = '<p>Loading stories...</p>';
       let query = supabaseClient
         .from('stories')
-        .select('id, title, content, created_at, category')
+        .select('id, title, content, created_at, category, admin_reply')
         .eq('is_approved', true);
       if (storyId) {
         query = query.eq('id', storyId).limit(1);


### PR DESCRIPTION
### Motivation
- Allow site admins to add an optional response to a user story that appears beneath the story content when present, without adding any frontend editing UI. 
- The database will gain an `admin_reply` column (to be applied manually with `ALTER TABLE stories ADD COLUMN admin_reply TEXT DEFAULT NULL;`) and the frontend must fetch and render that column when populated. 
- Preserve existing story layout, escaping, and share/meta controls while presenting admin replies with a subtle, readable style.

### Description
- Updated the Supabase query in `loadApprovedStories()` to include `admin_reply` in the selected columns (`.select('id, title, content, created_at, category, admin_reply')`).
- Extended `getStoryCardMarkup(story)` to compute `const adminReply = String(story.admin_reply || '').trim()` and render an `admin-reply` block only when `adminReply` is non-empty, using `escapeHTML(adminReply)` for safety and a heading `Admin Reply`.
- Added CSS rules for `.admin-reply`, `.admin-reply h5`, and `.admin-reply p` in the main stylesheet to provide a subtle tinted background, accent left border, smaller font, and clean spacing while reusing existing color variables.
- No UI was added to edit `admin_reply`; replies must be managed directly in Supabase as requested.

### Testing
- Ran `git diff --check` to ensure no whitespace/git-diff issues (passed).
- Extracted inline JavaScript and ran `node --check /tmp/namehim-inline-js.js` to validate the modified inline script syntax (passed).
- Attempted `npx playwright --version` to run visual checks, but the environment returned `403 Forbidden` from the npm registry so browser-based screenshot tests could not be run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b8de635e8832fa88e8a640ec82e4a)