### PR TITLE
Add centered yellow moderation notice to homepage header

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,12 +158,14 @@
       text-shadow: 0 0 18px rgba(96, 165, 250, 0.35);
     }
     .header-status {
-      flex: 1 1 20rem;
+      flex: 1 1 100%;
+      order: 3;
       margin: 0;
       text-align: center;
       font-size: 0.86rem;
       line-height: 1.4;
-      color: #fef3c7;
+      color: #fde047;
+      font-weight: 600;
     }
     h2 { margin-top: 0; margin-bottom: 1rem; font-size: 1.4rem; }
 
@@ -660,6 +662,7 @@
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
         <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
+      <p class="header-status">We apologize for the good faith reports that have been deleted recently. The moderator team is working harder to make sure that these reports are not deleted while trying to remove spam from the site. Thank you for your patience and your support.</p>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Provide a prominent, centered notice in the main header apologizing for recently deleted good-faith reports and reassuring users that moderators are working to avoid deleting legitimate reports while removing spam.

### Description
- Inserted a new paragraph with class `header-status` into `index.html` beneath the site title and before the navigation containing the requested moderation message.
- Updated the `.header-status` CSS to `flex: 1 1 100%`, `order: 3`, centered text, changed the color to `#fde047` (yellow), and set `font-weight: 600` to make the message visually prominent.

### Testing
- No automated tests were run; this is a static HTML/CSS layout and copy change that was verified by inspection of `index.html`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11ad1b1240832faca1a87c31127c17)