### PR TITLE
Temporarily comment out "Report this entry" UI and handler

### DIFF
--- a/index.html
+++ b/index.html
@@ -2099,7 +2099,9 @@ function addStoryTimestamp() {
           <td data-label="Categories"><div class="pills">${pillHTML}</div></td>
           <td data-label="Actions">
             <div class="row-actions">
+              <!-- Report this entry feature temporarily disabled.
               <button type="button" class="report-entry-btn" data-report-id="${escapeHTML(report.id || '')}">Report this entry</button>
+              -->
               <button type="button" class="report-share-btn" data-report-id="${escapeHTML(report.id || '')}">Share</button>
             </div>
           </td>
@@ -2742,46 +2744,47 @@ async function loadMapStats() {
       return;
     }
 
-    const button = event.target.closest('.report-entry-btn');
-    if (!button) return;
-    const reportId = button.getAttribute('data-report-id');
-    if (!reportId) return;
-
-    let reason = prompt(
-      'Why are you reporting this entry? (Optional, max 250 characters)\n\nThis helps moderators understand the issue.',
-      ''
-    );
-    if (reason === null) return;
-    reason = reason.trim().slice(0, 250);
-    if (reason === '') reason = null;
-
-    const submitterId = localStorage.getItem('submitter_id') || 'anonymous';
-
-    const originalText = button.textContent;
-    button.textContent = 'Submitting...';
-    button.disabled = true;
-
-    try {
-      const { error } = await supabaseClient
-        .from('report_flags')
-        .insert({
-          report_id: parseInt(reportId, 10),
-          reason: reason,
-          flagged_by: submitterId
-        });
-
-      if (error) {
-        console.error(error);
-        alert('Could not flag entry. Please try again later.');
-      } else {
-        alert('Entry #' + reportId + ' has been flagged for review.\nThank you for your report.');
-      }
-    } catch (err) {
-      alert('An error occurred. Please try again.');
-    } finally {
-      button.textContent = originalText;
-      button.disabled = false;
-    }
+    // Report this entry feature temporarily disabled.
+    // const button = event.target.closest('.report-entry-btn');
+    // if (!button) return;
+    // const reportId = button.getAttribute('data-report-id');
+    // if (!reportId) return;
+    //
+    // let reason = prompt(
+    //   'Why are you reporting this entry? (Optional, max 250 characters)\n\nThis helps moderators understand the issue.',
+    //   ''
+    // );
+    // if (reason === null) return;
+    // reason = reason.trim().slice(0, 250);
+    // if (reason === '') reason = null;
+    //
+    // const submitterId = localStorage.getItem('submitter_id') || 'anonymous';
+    //
+    // const originalText = button.textContent;
+    // button.textContent = 'Submitting...';
+    // button.disabled = true;
+    //
+    // try {
+    //   const { error } = await supabaseClient
+    //     .from('report_flags')
+    //     .insert({
+    //       report_id: parseInt(reportId, 10),
+    //       reason: reason,
+    //       flagged_by: submitterId
+    //     });
+    //
+    //   if (error) {
+    //     console.error(error);
+    //     alert('Could not flag entry. Please try again later.');
+    //   } else {
+    //     alert('Entry #' + reportId + ' has been flagged for review.\nThank you for your report.');
+    //   }
+    // } catch (err) {
+    //   alert('An error occurred. Please try again.');
+    // } finally {
+    //   button.textContent = originalText;
+    //   button.disabled = false;
+    // }
   });
 }
 


### PR DESCRIPTION
### Motivation
- The in-page "Report this entry" feature needs to be disabled temporarily while retaining the implementation for easy restoration.
- UI elements and event handler should be disabled without removing code so future re-enablement is straightforward.

### Description
- Commented out the `Report this entry` button markup in the browse table row inside `index.html` while keeping the `Share` button intact.
- Commented out the report-flag submission logic inside `setupReportActionHandler()` so clicks no longer trigger reporting behavior, leaving the original code in comments for easy reactivation.
- No other files were modified and all original logic remains present in comments for review or re-enable.

### Testing
- Ran a repository search with `rg -n "report this entry|report entry|report" .` to verify occurrences and confirm changes were scoped to `index.html`, which succeeded.
- Inspected the updated regions with `nl -ba index.html | sed -n '2096,2110p;2734,2796p'` to confirm the button and handler are commented out, which succeeded.
- Performed a local commit to record the change and verified `git status --short` showed the modified file, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11bca68b20832fbdc3e833534da45f)