### PR TITLE
Fix browse pagination when viewing filtered map results

### DIFF
--- a/index.html
+++ b/index.html
@@ -2955,24 +2955,34 @@ async function loadMapStats() {
 
   const pageValue = Number(target.getAttribute('data-page'));
   const navDirection = target.getAttribute('data-page-nav');
+  const isClientFilteredView = fullListLoaded;
+  const reportsForClientPagination = Array.isArray(currentFilteredReports) ? currentFilteredReports : allReports;
+  const totalPages = isClientFilteredView
+    ? Math.max(1, Math.ceil(reportsForClientPagination.length / REPORTS_PER_PAGE))
+    : Math.max(1, Math.ceil(allTotalCount / REPORTS_PER_PAGE));
+  const activePage = isClientFilteredView ? currentPage : currentBrowseServerPage;
 
-  // Get the current page from the active button
-  const activeBtn = browsePagination.querySelector('button.active');
-  let currentPage = activeBtn ? parseInt(activeBtn.textContent) : 1;
-
+  let nextPage = activePage;
   if (Number.isInteger(pageValue) && pageValue > 0) {
-    loadReports(pageValue);
-  } else if (navDirection === 'prev' && currentPage > 1) {
-    loadReports(currentPage - 1);
+    nextPage = pageValue;
+  } else if (navDirection === 'prev') {
+    nextPage = activePage - 1;
   } else if (navDirection === 'next') {
-    const totalPages = Math.ceil(allTotalCount / REPORTS_PER_PAGE);
-    if (currentPage < totalPages) loadReports(currentPage + 1);
+    nextPage = activePage + 1;
   } else if (navDirection === 'first') {
-    loadReports(1);
+    nextPage = 1;
   } else if (navDirection === 'last') {
-    const totalPages = Math.ceil(allTotalCount / REPORTS_PER_PAGE);
-    loadReports(totalPages);
+    nextPage = totalPages;
   }
+
+  nextPage = Math.min(Math.max(nextPage, 1), totalPages);
+
+  if (isClientFilteredView) {
+    renderPagedReports(reportsForClientPagination, nextPage);
+    return;
+  }
+
+  loadReports(nextPage);
       });
       reportForm.addEventListener('submit', handleSubmit);
       storyForm.addEventListener('submit', submitStory);


### PR DESCRIPTION
### Motivation
- Users reported that after selecting a state/country via the interactive map or dropdown, clicking pagination buttons always refreshed the first server page instead of navigating the filtered client-side pages.  
- The intent is to ensure pagination respects whether the app is showing server-paginated data or a full client-side filtered dataset and to avoid unexpectedly reloading server pages when in a filtered view.

### Description
- Updated the `browsePagination` click handler to detect client-filtered mode using `fullListLoaded` and compute `reportsForClientPagination` and `totalPages` from `currentFilteredReports` or `allReports`.  
- Compute a bounded `nextPage` from `data-page` or `data-page-nav` and clamp it between `1` and `totalPages`.  
- When in client-filtered mode, call `renderPagedReports(reportsForClientPagination, nextPage)` instead of `loadReports(...)`, otherwise call `loadReports(nextPage)`, preserving expected behavior for both modes.  
- This prevents pagination clicks from jumping back to page 1 when a state/country/map/search filter is active.

### Testing
- Ran `git diff --check` to verify no whitespace or formatting errors and it succeeded.  
- Inspected `git status --short` and `git diff` to confirm only `index.html` changed before committing.  
- Created a commit and generated the PR metadata with `make_pr` to record the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11db981660832fbd35fff87577b155)