### PR TITLE
Clarify submit form instructions to avoid personal info entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,6 +435,18 @@
     }
 
     .warning { color: #f59e0b; font-size: 0.85rem; margin-top: 0.5rem; }
+    .submit-form-alert {
+      margin: 0 0 1rem;
+      padding: 0.85rem 1rem;
+      border-radius: 10px;
+      border: 1px solid #f87171;
+      background: #2a1414;
+      color: #ffe4e6;
+      text-align: center;
+      font-size: 1rem;
+      font-weight: 700;
+      line-height: 1.4;
+    }
     .hidden { display: none !important; }
     .map-toggle-wrap {
       margin-bottom: 0.65rem;
@@ -731,6 +743,7 @@
       <section id="page-submit" class="page">
         <h2>Submit a Report</h2>
         <form id="report-form" class="panel" novalidate>
+          <p class="submit-form-alert">Do not enter your information here. Enter the name of the person you are reporting.</p>
           <div class="row">
             <label for="name">Name *</label>
             <input id="name" type="text" maxlength="20" required inputmode="text" />


### PR DESCRIPTION
### Motivation
- Prevent users from mistaking the Submit form for an account creation form by clearly instructing them not to enter their own personal information and to enter the name of the person being reported instead.

### Description
- Added a prominent banner message at the top of the submit form in `index.html` reading: "Do not enter your information here. Enter the name of the person you are reporting." placed inside the `#report-form` element.
- Added a new `.submit-form-alert` CSS rule to improve visibility and readability of the message.

### Testing
- No automated tests were executed for this UI/text/CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11dc5de36c832f93dbb1093b8ae30e)