### PR TITLE
Add hCaptcha to report submit form and worker verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -651,6 +651,7 @@
     
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
+  <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
   <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   <script src="mapdata.js?v=2026-04-24-3"></script>
   <script src="usmap.js?v=2026-04-24-4"></script>
@@ -976,11 +977,12 @@
 
           <div class="row">
             <div
-              class="cf-turnstile"
-              data-sitekey="0x4AAAAAADCC51BDmfY6JgSc"
+              id="report-hcaptcha"
+              class="h-captcha"
+              data-sitekey="097282a4-2ff0-44e4-bb50-f414265e1124"
               data-theme="dark"
             ></div>
-            <p id="turnstile-warning" class="warning hidden">Please complete the CAPTCHA verification.</p>
+            <p id="hcaptcha-warning" class="warning hidden">Please complete the CAPTCHA verification.</p>
           </div>
 
           <p id="rate-warning" class="message error hidden">You have reached the limit of 3 submissions in the last hour. Please try again later.</p>
@@ -1104,7 +1106,7 @@
     const reportForm = document.getElementById('report-form');
     const submitBtn = document.getElementById('submit-btn');
     const rateWarning = document.getElementById('rate-warning');
-    const turnstileWarning = document.getElementById('turnstile-warning');
+    const hcaptchaWarning = document.getElementById('hcaptcha-warning');
     const categoryContainer = document.getElementById('category-checkboxes');
     const reportCount = document.getElementById('report-count');
     const countryField = document.getElementById('country');
@@ -2505,15 +2507,19 @@ async function loadMapStats() {
       loadApprovedStories({ storyId });
     }
 
-    function getTurnstileToken() {
-      const tokenField = document.querySelector('[name="cf-turnstile-response"]');
+    function getHCaptchaToken() {
+      if (window.hcaptcha && typeof window.hcaptcha.getResponse === 'function') {
+        const widget = document.getElementById('report-hcaptcha');
+        return window.hcaptcha.getResponse(widget) || '';
+      }
+      const tokenField = document.querySelector('[name="h-captcha-response"]');
       return tokenField && tokenField.value ? tokenField.value : '';
     }
 
-    function resetTurnstileWidget() {
-      if (window.turnstile && typeof window.turnstile.reset === 'function') {
-        // Find the first turnstile iframe and reset
-        window.turnstile.reset();
+    function resetHCaptchaWidget() {
+      if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') {
+        const widget = document.getElementById('report-hcaptcha');
+        window.hcaptcha.reset(widget);
       }
     }
 
@@ -2641,12 +2647,12 @@ async function loadMapStats() {
     submitMessage.textContent = 'Report submitted successfully.';
     submitMessage.className = 'message success';
     reportForm.reset();
-    resetTurnstileWidget();
+    resetHCaptchaWidget();
     return;
     }
       submitMessage.textContent = '';
       submitMessage.className = 'message';
-      turnstileWarning.classList.add('hidden');
+      hcaptchaWarning.classList.add('hidden');
 
       if (updateRateLimitUI()) {
         submitMessage.textContent = 'Rate limit reached. Please wait before submitting again.';
@@ -2654,9 +2660,9 @@ async function loadMapStats() {
         return;
       }
 
-      const token = getTurnstileToken();
+      const token = getHCaptchaToken();
       if (!token) {
-        turnstileWarning.classList.remove('hidden');
+        hcaptchaWarning.classList.remove('hidden');
         return;
       }
 
@@ -2667,7 +2673,7 @@ async function loadMapStats() {
         country: sanitizeReportText(document.getElementById('country').value, MAX_BROWSE_FIELD_LENGTH),
         categories: getSelectedCategories(),
         submitter_uuid: getOrCreateSubmitterId(),
-        turnstileToken: token
+        hcaptchaToken: token
       };
 
       // Validation (keep your existing checks)
@@ -2731,14 +2737,14 @@ async function loadMapStats() {
         reportForm.reset();
         renderStateField();
         populateBrowseStateSelect();
-        resetTurnstileWidget();
+        resetHCaptchaWidget();
         submitMessage.textContent = 'Report submitted successfully.';
         submitMessage.className = 'message success';
         await loadReports();
         window.location.hash = '#/browse';
       } catch (error) {
         console.error('Submission error:', error);
-        resetTurnstileWidget();
+        resetHCaptchaWidget();
         submitMessage.textContent = error.message;
         submitMessage.className = 'message error';
       } finally {

--- a/worker/index.js
+++ b/worker/index.js
@@ -219,18 +219,23 @@ async function handleSubmitReport(request, env) {
     return errorResponse("Missing required fields", 400);
   }
 
-  const token = payload.turnstileToken;
+  const token = payload.hcaptchaToken;
   if (!token) return errorResponse("CAPTCHA token missing", 400);
 
-  const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+  const verifyRes = await fetch("https://api.hcaptcha.com/siteverify", {
     method: "POST",
-    body: new URLSearchParams({ secret: env.TURNSTILE_SECRET_KEY, response: token }),
+    body: new URLSearchParams({
+      secret: env.HCAPTCHA_SECRET,
+      response: token,
+      remoteip: ip || "",
+      sitekey: env.HCAPTCHA_SITEKEY || ""
+    }),
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
   const verifyData = await verifyRes.json();
   if (!verifyData.success) return errorResponse("Invalid CAPTCHA", 400);
 
-  const { turnstileToken, ...reportData } = payload;
+  const { hcaptchaToken, ...reportData } = payload;
   const insertRes = await supabaseFetch(supabaseUrl, supabaseKey, "/rest/v1/reports", {
     method: "POST",
     headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
### Motivation

- Replace the client-side Turnstile widget used on the report submission form with hCaptcha and perform server-side verification so automated spam submissions are blocked by hCaptcha.
- Keep the existing Turnstile flow intact for the community story form while migrating the main `/submit` flow to hCaptcha.

### Description

- Added the hCaptcha loader script to `index.html` and replaced the report form widget with an hCaptcha container (`id="report-hcaptcha"`) and a dedicated warning element (`id="hcaptcha-warning"`).
- Updated client JavaScript in `index.html` to read the hCaptcha response via `getHCaptchaToken()`, reset it with `resetHCaptchaWidget()`, validate presence before submit, and send `hcaptchaToken` in the JSON payload to the API.
- Updated the worker `handleSubmitReport` handler in `worker/index.js` to read `payload.hcaptchaToken`, call `https://api.hcaptcha.com/siteverify` using the environment variables `HCAPTCHA_SECRET` and `HCAPTCHA_SITEKEY`, and strip `hcaptchaToken` before inserting the report into Supabase.
- Left the community story Turnstile flow and its verification unchanged so that story submissions continue to use Cloudflare Turnstile.

### Testing

- Performed a static syntax check on the worker with `node --check worker/index.js`, which completed successfully.
- Ran repository-wide searches and smoke-checked `index.html` to ensure token name changes (`hcaptchaToken`) and DOM IDs (`report-hcaptcha`, `hcaptcha-warning`) were consistently updated, with no runtime JavaScript syntax errors detected by the static check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e2f8b1f8832f83e322a36d40df95)