### PR TITLE
Force hCaptcha widget into challenge mode by adding attribute

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,6 +981,7 @@
               class="h-captcha"
               data-sitekey="097282a4-2ff0-44e4-bb50-f414265e1124"
               data-theme="dark"
+              data-hcaptcha-type="challenge"
             ></div>
             <p id="hcaptcha-warning" class="warning hidden">Please complete the CAPTCHA verification.</p>
           </div>


### PR DESCRIPTION
### Motivation
- Users reported the hCaptcha widget remaining passive despite dashboard settings, so the widget markup should explicitly request challenge behavior.

### Description
- Updated the report form hCaptcha element in `index.html` (`#report-hcaptcha`) to include `data-hcaptcha-type="challenge"` so the widget is instructed to always present a challenge.
- Change is limited to a single attribute insertion on the existing hCaptcha container element.

### Testing
- Located the widget markup with `sed -n '950,1020p' index.html` to confirm target insertion point, which succeeded.  
- Applied a scripted replacement that printed `updated` to confirm the attribute was inserted, which succeeded.  
- Verified the updated markup with `nl -ba index.html | sed -n '976,990p'` and inspected the file diff to confirm only the single attribute was added, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e650c014832fae554a30dbd24d46)