### PR TITLE
Replace Turnstile with hCaptcha for story/report flows and fix verification

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,7 +652,6 @@
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
-  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   <script src="mapdata.js?v=2026-04-24-3"></script>
   <script src="usmap.js?v=2026-04-24-4"></script>
   <script src="wmapdata.js?v=2026-04-25-1"></script>
@@ -1021,7 +1020,12 @@
   </select>
 </div>
     <div class="row">
-      <div class="cf-turnstile" id="story-turnstile" data-theme="dark"></div>
+      <div
+        id="story-hcaptcha"
+        class="h-captcha"
+        data-sitekey="097282a4-2ff0-44e4-bb50-f414265e1124"
+        data-theme="dark"
+      ></div>
       <p id="story-turnstile-warning" class="warning hidden">Please complete the CAPTCHA.</p>
     </div>
     <p id="story-rate-warning" class="message error hidden">You've reached the limit. Please wait before submitting another story.</p>
@@ -2552,29 +2556,16 @@ async function loadMapStats() {
     }
 
     function openStoryForm() {
-  if (!storyForm || !showStoryFormBtn) return;
-  storyForm.classList.remove('hidden');
-  showStoryFormBtn.classList.add('hidden');
-  showStoryFormBtn.setAttribute('aria-expanded', 'true');
+      if (!storyForm || !showStoryFormBtn) return;
+      storyForm.classList.remove('hidden');
+      showStoryFormBtn.classList.add('hidden');
+      showStoryFormBtn.setAttribute('aria-expanded', 'true');
 
-  const turnstileDiv = storyForm.querySelector('.cf-turnstile');
-  if (!turnstileDiv) return;
-
-  // Ensure sitekey is set (only needed once)
-  if (!turnstileDiv.getAttribute('data-sitekey')) {
-    turnstileDiv.setAttribute('data-sitekey', '0x4AAAAAADCC51BDmfY6JgSc');
-  }
-
-  // Check if Turnstile already rendered a widget inside this div
-  const existingWidget = turnstileDiv.querySelector('iframe');
-  if (existingWidget && window.turnstile) {
-    // Widget exists – just reset it
-    window.turnstile.reset(turnstileDiv);
-  } else if (window.turnstile) {
-    // Widget does not exist – render it now
-    window.turnstile.render(turnstileDiv);
-  }
-}
+      if (!window.hcaptcha || typeof window.hcaptcha.reset !== 'function') return;
+      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      if (!storyTokenField || !storyTokenField.value) return;
+      window.hcaptcha.reset();
+    }
 
     async function submitStory(event) {
       event.preventDefault();
@@ -2602,21 +2593,12 @@ async function loadMapStats() {
       let category = document.getElementById('story-category').value;
       if (!category) category = 'General';
 
-      const turnstileWidget = storyForm.querySelector('.cf-turnstile');
-      if (!turnstileWidget) {
-        storyMessage.textContent = 'Captcha widget missing. Please refresh the page.';
-        storyMessage.className = 'message error';
-        return;
-      }
-
-      let token = null;
-      if (window.turnstile) {
-        token = window.turnstile.getResponse(turnstileWidget);
-        if (!token) {
-          window.turnstile.reset(turnstileWidget);
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          token = window.turnstile.getResponse(turnstileWidget);
-        }
+      let token = '';
+      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      if (storyTokenField && storyTokenField.value) {
+        token = storyTokenField.value;
+      } else if (window.hcaptcha && typeof window.hcaptcha.getResponse === 'function') {
+        token = window.hcaptcha.getResponse();
       }
 
       if (!token) {
@@ -2635,7 +2617,7 @@ async function loadMapStats() {
             content,
             category,
             submitter_uuid: localStorage.getItem('submitter_id'),
-            turnstileToken: token
+            hcaptchaToken: token
           })
         });
         const result = await response.json();
@@ -2647,9 +2629,7 @@ async function loadMapStats() {
         storyMessage.textContent = 'Thank you. Your story has been submitted for review.';
         storyMessage.className = 'message success';
         storyForm.reset();
-        if (window.turnstile && turnstileWidget) {
-          window.turnstile.reset(turnstileWidget);
-        }
+        if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') window.hcaptcha.reset();
         if (window.location.hash === '#/community') loadApprovedStories();
       } catch (error) {
         console.error('Story submission error:', error);

--- a/worker/index.js
+++ b/worker/index.js
@@ -227,8 +227,7 @@ async function handleSubmitReport(request, env) {
     body: new URLSearchParams({
       secret: env.HCAPTCHA_SECRET,
       response: token,
-      remoteip: ip || "",
-      sitekey: env.HCAPTCHA_SITEKEY || ""
+      remoteip: ip || ""
     }),
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
@@ -290,16 +289,20 @@ async function handleSubmitStory(request, env) {
     return errorResponse("Invalid JSON", 400);
   }
 
-  const { title, content, submitter_uuid, turnstileToken } = payload;
+  const { title, content, submitter_uuid, hcaptchaToken } = payload;
   if (!content || typeof content !== "string") {
     return errorResponse("Missing story content", 400);
   }
   if (content.length > 1000) return errorResponse("Story too long", 400);
-  if (!turnstileToken) return errorResponse("CAPTCHA token missing", 400);
+  if (!hcaptchaToken) return errorResponse("CAPTCHA token missing", 400);
 
-  const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+  const verifyRes = await fetch("https://api.hcaptcha.com/siteverify", {
     method: "POST",
-    body: new URLSearchParams({ secret: env.TURNSTILE_SECRET_KEY, response: turnstileToken }),
+    body: new URLSearchParams({
+      secret: env.HCAPTCHA_SECRET,
+      response: hcaptchaToken,
+      remoteip: ip || ""
+    }),
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
   const verifyData = await verifyRes.json();


### PR DESCRIPTION
### Motivation

- Remove Cloudflare Turnstile-related console errors and mismatched widget usage after migrating the app to hCaptcha.
- Make CAPTCHA handling consistent between the report form and community story form to avoid server-side `Invalid CAPTCHA` failures when frontend and backend disagree on token type.

### Description

- Removed the Turnstile script include and replaced the community story form widget markup with an hCaptcha widget (`<div class="h-captcha" ...>` using the existing site key). 
- Updated client logic in `index.html` to read/reset `hcaptchaToken` (via `window.hcaptcha.getResponse()` / `window.hcaptcha.reset()` and hidden `h-captcha-response` field) and to send `hcaptchaToken` from `submitStory` instead of `turnstileToken`.
- Modified `openStoryForm` and story submit/reset flows to use `window.hcaptcha` safely if available and to handle the hCaptcha token fallback from the DOM.
- Updated `worker/index.js` verification: `/submit` and `/submit-story` now validate tokens against `https://api.hcaptcha.com/siteverify` using `env.HCAPTCHA_SECRET`, and removed the strict `sitekey` param from the `/submit` verification request to avoid false negatives when keys drift; payload field `turnstileToken` was replaced with `hcaptchaToken` where appropriate.

### Testing

- Ran `node --check worker/index.js` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e99e6420832f8d848551770422ae)