### PR TITLE
Switch community story CAPTCHA from Turnstile to hCaptcha and verify server-side

### DIFF
--- a/index.html
+++ b/index.html
@@ -652,7 +652,6 @@
   </style>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
-  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   <script src="mapdata.js?v=2026-04-24-3"></script>
   <script src="usmap.js?v=2026-04-24-4"></script>
   <script src="wmapdata.js?v=2026-04-25-1"></script>
@@ -982,6 +981,7 @@
               data-sitekey="097282a4-2ff0-44e4-bb50-f414265e1124"
               data-theme="dark"
               data-hcaptcha-type="challenge"
+              data-size="normal"
               data-callback="onHCaptchaSuccess"
               data-expired-callback="onHCaptchaExpired"
               data-error-callback="onHCaptchaError"
@@ -1021,7 +1021,16 @@
   </select>
 </div>
     <div class="row">
-      <div class="cf-turnstile" id="story-turnstile" data-theme="dark"></div>
+      <div
+        id="story-hcaptcha"
+        class="h-captcha"
+        data-sitekey="097282a4-2ff0-44e4-bb50-f414265e1124"
+        data-theme="dark"
+        data-size="normal"
+        data-callback="onStoryHCaptchaSuccess"
+        data-expired-callback="onStoryHCaptchaExpired"
+        data-error-callback="onStoryHCaptchaError"
+      ></div>
       <p id="story-turnstile-warning" class="warning hidden">Please complete the CAPTCHA.</p>
     </div>
     <p id="story-rate-warning" class="message error hidden">You've reached the limit. Please wait before submitting another story.</p>
@@ -2513,6 +2522,7 @@ async function loadMapStats() {
 
 
     let hcaptchaTokenValue = '';
+    let storyHcaptchaTokenValue = '';
 
     window.onHCaptchaSuccess = function onHCaptchaSuccess(token) {
       hcaptchaTokenValue = token || '';
@@ -2525,6 +2535,16 @@ async function loadMapStats() {
 
     window.onHCaptchaError = function onHCaptchaError() {
       hcaptchaTokenValue = '';
+    };
+    window.onStoryHCaptchaSuccess = function onStoryHCaptchaSuccess(token) {
+      storyHcaptchaTokenValue = token || '';
+      if (storyTurnstileWarning) storyTurnstileWarning.classList.add('hidden');
+    };
+    window.onStoryHCaptchaExpired = function onStoryHCaptchaExpired() {
+      storyHcaptchaTokenValue = '';
+    };
+    window.onStoryHCaptchaError = function onStoryHCaptchaError() {
+      storyHcaptchaTokenValue = '';
     };
 
     function getHCaptchaToken() {
@@ -2552,29 +2572,16 @@ async function loadMapStats() {
     }
 
     function openStoryForm() {
-  if (!storyForm || !showStoryFormBtn) return;
-  storyForm.classList.remove('hidden');
-  showStoryFormBtn.classList.add('hidden');
-  showStoryFormBtn.setAttribute('aria-expanded', 'true');
+      if (!storyForm || !showStoryFormBtn) return;
+      storyForm.classList.remove('hidden');
+      showStoryFormBtn.classList.add('hidden');
+      showStoryFormBtn.setAttribute('aria-expanded', 'true');
 
-  const turnstileDiv = storyForm.querySelector('.cf-turnstile');
-  if (!turnstileDiv) return;
-
-  // Ensure sitekey is set (only needed once)
-  if (!turnstileDiv.getAttribute('data-sitekey')) {
-    turnstileDiv.setAttribute('data-sitekey', '0x4AAAAAADCC51BDmfY6JgSc');
-  }
-
-  // Check if Turnstile already rendered a widget inside this div
-  const existingWidget = turnstileDiv.querySelector('iframe');
-  if (existingWidget && window.turnstile) {
-    // Widget exists – just reset it
-    window.turnstile.reset(turnstileDiv);
-  } else if (window.turnstile) {
-    // Widget does not exist – render it now
-    window.turnstile.render(turnstileDiv);
-  }
-}
+      if (!window.hcaptcha || typeof window.hcaptcha.reset !== 'function') return;
+      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      if (!storyTokenField || !storyTokenField.value) return;
+      window.hcaptcha.reset();
+    }
 
     async function submitStory(event) {
       event.preventDefault();
@@ -2602,21 +2609,12 @@ async function loadMapStats() {
       let category = document.getElementById('story-category').value;
       if (!category) category = 'General';
 
-      const turnstileWidget = storyForm.querySelector('.cf-turnstile');
-      if (!turnstileWidget) {
-        storyMessage.textContent = 'Captcha widget missing. Please refresh the page.';
-        storyMessage.className = 'message error';
-        return;
-      }
-
-      let token = null;
-      if (window.turnstile) {
-        token = window.turnstile.getResponse(turnstileWidget);
-        if (!token) {
-          window.turnstile.reset(turnstileWidget);
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          token = window.turnstile.getResponse(turnstileWidget);
-        }
+      let token = storyHcaptchaTokenValue || '';
+      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      if (storyTokenField && storyTokenField.value) {
+        token = storyTokenField.value;
+      } else if (window.hcaptcha && typeof window.hcaptcha.getResponse === 'function') {
+        token = window.hcaptcha.getResponse();
       }
 
       if (!token) {
@@ -2635,7 +2633,7 @@ async function loadMapStats() {
             content,
             category,
             submitter_uuid: localStorage.getItem('submitter_id'),
-            turnstileToken: token
+            hcaptchaToken: token
           })
         });
         const result = await response.json();
@@ -2647,9 +2645,8 @@ async function loadMapStats() {
         storyMessage.textContent = 'Thank you. Your story has been submitted for review.';
         storyMessage.className = 'message success';
         storyForm.reset();
-        if (window.turnstile && turnstileWidget) {
-          window.turnstile.reset(turnstileWidget);
-        }
+        storyHcaptchaTokenValue = '';
+        if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') window.hcaptcha.reset();
         if (window.location.hash === '#/community') loadApprovedStories();
       } catch (error) {
         console.error('Story submission error:', error);

--- a/worker/index.js
+++ b/worker/index.js
@@ -227,13 +227,16 @@ async function handleSubmitReport(request, env) {
     body: new URLSearchParams({
       secret: env.HCAPTCHA_SECRET,
       response: token,
-      remoteip: ip || "",
-      sitekey: env.HCAPTCHA_SITEKEY || ""
+      remoteip: ip || ""
     }),
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
   const verifyData = await verifyRes.json();
-  if (!verifyData.success) return errorResponse("Invalid CAPTCHA", 400);
+  if (!verifyData.success) {
+    const errorCodes = Array.isArray(verifyData["error-codes"]) ? verifyData["error-codes"].join(", ") : "unknown";
+    console.error("hCaptcha verify failed (/submit):", errorCodes, verifyData);
+    return errorResponse(`Invalid CAPTCHA (${errorCodes})`, 400);
+  }
 
   const { hcaptchaToken, ...reportData } = payload;
   const insertRes = await supabaseFetch(supabaseUrl, supabaseKey, "/rest/v1/reports", {
@@ -290,20 +293,28 @@ async function handleSubmitStory(request, env) {
     return errorResponse("Invalid JSON", 400);
   }
 
-  const { title, content, submitter_uuid, turnstileToken } = payload;
+  const { title, content, submitter_uuid, hcaptchaToken } = payload;
   if (!content || typeof content !== "string") {
     return errorResponse("Missing story content", 400);
   }
   if (content.length > 1000) return errorResponse("Story too long", 400);
-  if (!turnstileToken) return errorResponse("CAPTCHA token missing", 400);
+  if (!hcaptchaToken) return errorResponse("CAPTCHA token missing", 400);
 
-  const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+  const verifyRes = await fetch("https://api.hcaptcha.com/siteverify", {
     method: "POST",
-    body: new URLSearchParams({ secret: env.TURNSTILE_SECRET_KEY, response: turnstileToken }),
+    body: new URLSearchParams({
+      secret: env.HCAPTCHA_SECRET,
+      response: hcaptchaToken,
+      remoteip: ip || ""
+    }),
     headers: { "Content-Type": "application/x-www-form-urlencoded" }
   });
   const verifyData = await verifyRes.json();
-  if (!verifyData.success) return errorResponse("Invalid CAPTCHA", 400);
+  if (!verifyData.success) {
+    const errorCodes = Array.isArray(verifyData["error-codes"]) ? verifyData["error-codes"].join(", ") : "unknown";
+    console.error("hCaptcha verify failed (/submit-story):", errorCodes, verifyData);
+    return errorResponse(`Invalid CAPTCHA (${errorCodes})`, 400);
+  }
 
   const insertRes = await supabaseFetch(supabaseUrl, supabaseKey, "/rest/v1/stories", {
     method: "POST",


### PR DESCRIPTION
### Motivation
- Standardize CAPTCHA provider across the site by replacing Cloudflare Turnstile usage for community story submissions with hCaptcha to match the main report flow.
- Simplify client/server token handling by sending a single `hcaptchaToken` field and improve server-side verification logging for troubleshooting.

### Description
- Replaced the story form Turnstile markup and script usage with an hCaptcha widget (`story-hcaptcha`) and added callbacks and a `storyHcaptchaTokenValue` client variable (`onStoryHCaptchaSuccess`, `onStoryHCaptchaExpired`, `onStoryHCaptchaError`).
- Updated client-side `submitStory` to collect an hCaptcha token (from the hidden field or `hcaptcha.getResponse()`), send it as `hcaptchaToken`, reset the hCaptcha widget after successful submission, and removed Turnstile-specific calls.
- Updated worker handlers to validate `hcaptchaToken` for both report and story submissions using `https://api.hcaptcha.com/siteverify`, pass `remoteip` where applicable, and return improved error messages while logging hCaptcha error codes on verification failure.
- Removed Turnstile-specific rendering/reset logic and the Cloudflare Turnstile script include, and added defensive checks around widget/token access.

### Testing
- Ran CI lint and build checks; they completed successfully.
- No new automated tests were added for CAPTCHA behavior in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e99e6420832f8d848551770422ae)