### PR TITLE
Add 1/min and 3/hour rate-limit windows for report and story submissions

### DIFF
--- a/worker/index.js
+++ b/worker/index.js
@@ -193,7 +193,10 @@ async function handleSubmitReport(request, env) {
   const rateLimitOptions = {
     key: `${ip}:submit`,
     limitKey: "submit",
-    windows: [{ limit: 3, window: 3600 }] // 3 per hour (change to 1 if you prefer)
+    windows: [
+      { limit: 1, window: 60 },
+      { limit: 3, window: 3600 }
+    ]
   };
   try {
     const { success } = await env.RATELIMITER.limit(rateLimitOptions);
@@ -271,7 +274,10 @@ async function handleSubmitStory(request, env) {
   const rateLimitOptions = {
     key: `${ip}:story`,
     limitKey: "story",
-    windows: [{ limit: 3, window: 3600 }] // 3 per hour
+    windows: [
+      { limit: 1, window: 60 },
+      { limit: 3, window: 3600 }
+    ]
   };
   try {
     const { success } = await env.RATELIMITER.limit(rateLimitOptions);


### PR DESCRIPTION
### Motivation
- Enforce a stricter per-minute submission cap while keeping the existing per-hour cap for both report and story endpoints.
- Keep existing response handling and Cloudflare rate limiter behavior unchanged per request.

### Description
- Updated `rateLimitOptions.windows` in `handleSubmitReport` to `[{ limit: 1, window: 60 }, { limit: 3, window: 3600 }]`.
- Updated `rateLimitOptions.windows` in `handleSubmitStory` to `[{ limit: 1, window: 60 }, { limit: 3, window: 3600 }]`.
- Only `worker/index.js` was modified and no other logic, error messages, database, or frontend code was changed.

### Testing
- Located call sites with `rg` and confirmed targets in `worker/index.js` (success).
- Applied the patch and committed with `git commit` which succeeded and produced a new commit hash (success).
- Inspected the updated file region with `nl -ba worker/index.js | sed -n '188,286p'` to verify the new `windows` arrays (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11f67ea0c4832faf94f32a3ff0ed02)