### PR TITLE
Make Admin Log collapsible and collapsed by default on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -203,6 +203,44 @@
       scroll-margin-top: 6rem;
     }
 
+    .collapsible-card {
+      border: 1px solid var(--border);
+      border-radius: 0.6rem;
+      background: var(--panel-2);
+      padding: 0.8rem 0.9rem;
+    }
+
+    .collapsible-card summary {
+      cursor: pointer;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .collapsible-card summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .collapsible-card summary::before {
+      content: '▸';
+      font-size: 0.95rem;
+      color: var(--accent);
+      transition: transform 0.2s ease;
+    }
+
+    .collapsible-card[open] summary::before {
+      transform: rotate(90deg);
+    }
+
+    .collapsible-card summary h3 {
+      margin: 0;
+    }
+
+    .collapsible-card-content {
+      margin-top: 0.75rem;
+    }
+
     p {
       margin: 0;
       color: #dbe3ee;
@@ -424,11 +462,17 @@
           <p>Contact: namehim.app@proton.me</p>
         </section>
         <section id="admin-log">
-          <h3>Admin Log</h3>
-          <p><strong>6:30 a.m. May 6, 2026 (PDT):</strong> Hello everyone, we now have two more moderators on the team, and both of them and I are working hard every day to take down spam and false retaliation reports on the site. I've also agreed to share 40% of any tips or donations that come in to the site with these moderators, so thank you to everyone who's helped out so far. All three of us are working very hard to make this site functional and useful. Also, I just wanted to remind everybody that even if there is spam temporarily, it does not take away from the actual names that are up here, and our database is searchable by name, city, state, or country.</p>
-          <p><strong>2:20 p.m. May 2, 2026 (PDT):</strong> Hello everyone, thank you to everyone who has supported the site so far. From the bottom of my heart, my family and I appreciate you. The support I've received so far has covered the costs of hosting and storing the database that I spent initially on the project. I've been putting a lot of time in every day to improve the site's functionality and add more user-friendly features. For instance, one thing I've done is update the Community tab so you can now select a category for your story, and you can choose Survivor Story if it might contain content that could trigger others. That way, people can decide whether they want to read those stories or stick with other categories like empowerment and hope. I've also added a resources page that provides information for almost every country so far, including emergency numbers and hotlines if you're in the middle of a crisis or an unsafe situation. Thank you again, everyone. I will continue putting my time into maintaining and updating the site so it remains a functional space and tool for survivors like myself. If you have any questions, feel free to reach out. And thank you so much to the person who created and submitted the user poster below.
-          I am still dedicating a lot of time to this site and our family still does not have a car anymore so support is still appreciated and helpful.</p>
-          <p><strong>2:00 a.m. April 27, 2026 (PDT):</strong> The site suffered a very intelligent malicious attack, but after many hours of problem solving and updating the site and the database, it has been fixed and should stop this from happening in the future. In this process, there may have been an accidental deletion of some entries, so if you submitted your entry around the time the site had between 18,000 and 21,000 reports, please check if your submission is still there. If it is not, feel free to submit again.</p>
+          <details class="collapsible-card">
+            <summary>
+              <h3>Admin Log</h3>
+            </summary>
+            <div class="collapsible-card-content">
+              <p><strong>6:30 a.m. May 6, 2026 (PDT):</strong> Hello everyone, we now have two more moderators on the team, and both of them and I are working hard every day to take down spam and false retaliation reports on the site. I've also agreed to share 40% of any tips or donations that come in to the site with these moderators, so thank you to everyone who's helped out so far. All three of us are working very hard to make this site functional and useful. Also, I just wanted to remind everybody that even if there is spam temporarily, it does not take away from the actual names that are up here, and our database is searchable by name, city, state, or country.</p>
+              <p><strong>2:20 p.m. May 2, 2026 (PDT):</strong> Hello everyone, thank you to everyone who has supported the site so far. From the bottom of my heart, my family and I appreciate you. The support I've received so far has covered the costs of hosting and storing the database that I spent initially on the project. I've been putting a lot of time in every day to improve the site's functionality and add more user-friendly features. For instance, one thing I've done is update the Community tab so you can now select a category for your story, and you can choose Survivor Story if it might contain content that could trigger others. That way, people can decide whether they want to read those stories or stick with other categories like empowerment and hope. I've also added a resources page that provides information for almost every country so far, including emergency numbers and hotlines if you're in the middle of a crisis or an unsafe situation. Thank you again, everyone. I will continue putting my time into maintaining and updating the site so it remains a functional space and tool for survivors like myself. If you have any questions, feel free to reach out. And thank you so much to the person who created and submitted the user poster below.
+              I am still dedicating a lot of time to this site and our family still does not have a car anymore so support is still appreciated and helpful.</p>
+              <p><strong>2:00 a.m. April 27, 2026 (PDT):</strong> The site suffered a very intelligent malicious attack, but after many hours of problem solving and updating the site and the database, it has been fixed and should stop this from happening in the future. In this process, there may have been an accidental deletion of some entries, so if you submitted your entry around the time the site had between 18,000 and 21,000 reports, please check if your submission is still there. If it is not, feel free to submit again.</p>
+            </div>
+          </details>
         </section>
         <section id="poster">
           <h3>User submitted poster</h3>


### PR DESCRIPTION
### Motivation
- Reduce visual clutter on the About page by hiding the verbose Admin Log behind a collapsed control by default.
- Keep the existing `#admin-log` anchor and content intact while improving discoverability and UX for users who want to read the log.

### Description
- Added a `.collapsible-card` CSS block with styles for the card, summary row, custom caret, and open-state rotation.
- Replaced the static Admin Log markup with a native `<details class="collapsible-card">` / `<summary>` wrapper and moved the log entries into a `.collapsible-card-content` container so the card is collapsed by default (no `open` attribute).
- Preserved the `section id="admin-log"` anchor so existing links/navigation still target the same section.

### Testing
- Verified the updated markup and styles by printing the modified ranges of `about.html` with `nl` and `sed` to confirm the new CSS and `<details>` wrapper were inserted correctly, and the Admin Log content remains present, which succeeded.
- No unit/UI test suite exists for this static HTML change, so no automated browser rendering tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b6c116b0832f8fe7ee9055c1949a)