### PR TITLE
Temporarily comment out Ko-fi widget on About page

### DIFF
--- a/about.html
+++ b/about.html
@@ -440,10 +440,12 @@
           <p>Hello, I built this open source project as a single developer and have paid for the hosting and maintaining of the site and database it displays with user donations. I've put many hours into developing,maintaining, and moderating it and me and the moderating team are keeping up with it daily. On a personal note, my fiance and I are raising our newborn son and we are already using credit to maintain our bills and our rental.  </p>
           <p>If you want to support our family and the volunteer moderators by helping with a tip or donation, it is greatly appreciated.</p>
           <div class="support-buttons">
+            <!--
             <div>
               <script src='https://storage.ko-fi.com/cdn/widget/Widget_2.js'></script>
               <script>kofiwidget2.init('Support me on Ko-fi', '#72a4f2', 'R5R81YISDW');kofiwidget2.draw();</script>
             </div>
+            -->
             <div>
               <style>.pp-Y88TMRL6PM2EQ{text-align:center;border:none;border-radius:0.25rem;min-width:11.625rem;padding:0 2rem;height:2.625rem;font-weight:bold;background-color:#FFD140;color:#000000;font-family:"Helvetica Neue",Arial,sans-serif;font-size:1rem;line-height:1.25rem;cursor:pointer;}</style>
               <form action="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" method="post" target="_blank" style="display:inline-grid;justify-items:center;align-content:start;gap:0.5rem;">


### PR DESCRIPTION
### Motivation
- Temporarily hide the Ko-fi donation widget on the About page because the Ko-fi link is currently not working while keeping the PayPal donation option visible and preserving the original Ko-fi code for easy restoration.

### Description
- Wrapped the existing Ko-fi widget block in HTML comments in `about.html` inside the Financial Transparency and Optional Support section, leaving the PayPal form and styling untouched.

### Testing
- Applied the patch and verified the commented block and the intact PayPal form by inspecting the file with `nl -ba /workspace/namehim/about.html | sed -n '438,456p'`, which showed the Ko-fi block commented and the PayPal form present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c0a4cd48832f847e5c6c5cc82873)