### PR TITLE
Remove browse apology header

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,16 +157,6 @@
       letter-spacing: 0.02em;
       text-shadow: 0 0 18px rgba(96, 165, 250, 0.35);
     }
-    .header-status {
-      flex: 1 1 100%;
-      order: 3;
-      margin: 0;
-      text-align: center;
-      font-size: 0.86rem;
-      line-height: 1.4;
-      color: #fde047;
-      font-weight: 600;
-    }
     h2 { margin-top: 0; margin-bottom: 1rem; font-size: 1.4rem; }
 
     .controls {
@@ -674,7 +664,6 @@
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
         <p id="report-count" class="report-count">Loading reports and counting...</p>
       </div>
-      <p class="header-status">We apologize for the good faith reports that have been deleted recently. The moderator team is working harder to make sure that these reports are not deleted while trying to remove spam from the site. Thank you for your patience and your support.</p>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
         <a href="#/submit" class="nav-link" data-route="#/submit">Submit</a>


### PR DESCRIPTION
### Motivation
- Remove the yellow apology/status banner from the site header to simplify the header layout and eliminate an unused style rule.

### Description
- Deleted the `<p class="header-status">…</p>` banner and removed the accompanying `.header-status` CSS block from `index.html`.

### Testing
- Ran `rg -n "header-status|good faith reports|We apologize" index.html` which returned no matches, indicating the text and style were removed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a199289c3b0832fb0ba4e171690049c)