### PR TITLE
Update site alert restoration message

### DIFF
--- a/about.html
+++ b/about.html
@@ -419,7 +419,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, but the community stories may have been lost. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>

--- a/index.html
+++ b/index.html
@@ -737,7 +737,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, but the community stories may have been lost. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="about.html#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>

--- a/resources.html
+++ b/resources.html
@@ -249,7 +249,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, but the community stories may have been lost. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="about.html#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>


### PR DESCRIPTION
### Motivation
- Ensure the top site alert explicitly promises restoration of the user-submitted community page stories and keep messaging consistent across site pages.

### Description
- Replaced the site-alert paragraph in `index.html`, `resources.html`, and `about.html` to read: "We are working to restore full functionality to the site, and restore the user-submitted community page stories...".

### Testing
- Ran `git diff --check` which passed and verified the replacements with `rg -n "and restore the user-submitted community page stories|community stories may have been lost" index.html resources.html about.html`; the changes were found in all three files, and an automated Playwright screenshot attempt failed because Playwright is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ed4df2d28832f960694461b0dee1d)