### PR TITLE
Switch frontend to Worker API, add D1-backed stories, and replace hCaptcha with Turnstile

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Community-driven safety awareness platform. Users can anonymously submit reports
 ## Tech stack
 
 - **Frontend:** HTML/CSS/JS (no build step), hosted on Cloudflare Pages
-- **Backend API:** Cloudflare Worker (filters, CAPTCHA, cache, Supabase proxy)
-- **Database:** Supabase (PostgreSQL with Row Level Security)
+- **Backend API:** Cloudflare Worker (filters, Turnstile verification, KV cache, D1 access)
+- **Database:** Cloudflare D1 (with Cloudflare KV for cached report lists)
 - **CAPTCHA:** Cloudflare Turnstile
 - **Maps:** Simplemaps US & World maps (interactive)
 
@@ -30,17 +30,20 @@ Community-driven safety awareness platform. Users can anonymously submit reports
 
 The frontend communicates with a Worker at `https://api.namehim.app/` which provides:
 
-- `GET /filtered-reports` – returns all reports after filtering out blocked names and malicious payloads (cached in Cloudflare KV)
-- `POST /submit` – submits a new safety report (validates Turnstile, inserts into Supabase)
-- `POST /submit-story` – submits a community story (requires approval, not live immediately)
-- - `GET /version` – returns the current Git commit hash and source link, allowing anyone to verify that the live worker matches the public code.
+- `GET /reports` – returns paginated reports from D1 after filtering blocked names (cached in Cloudflare KV)
+- `GET /filtered-reports` – legacy full-list report endpoint for search/filter fallback
+- `GET /stats` – returns state and country report counts for maps
+- `GET /stories` – returns approved community stories from D1
+- `POST /submit` – submits a new safety report (validates Turnstile, inserts into D1)
+- `POST /submit-story` – submits a community story for review (validates Turnstile, inserts into D1)
+- `GET /version` – returns the current Git commit hash and source link, allowing anyone to verify that the live worker matches the public code.
 
-The worker uses environment variables for secrets (SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, TURNSTILE_SECRET_KEY). The source code is open in /worker/index.js and is automatically deployed from this repository via Cloudflare Workers Git integration (branch: main, root directory: worker/).
+The worker uses a D1 binding named `DB`, a KV binding named `CACHE_KV`, and the `TURNSTILE_SECRET_KEY` environment variable. The source code is open in /worker/index.js and is automatically deployed from this repository via Cloudflare Workers Git integration (branch: main, root directory: worker/).
 Every push to main updates the live worker instantly. Secrets remain in Cloudflare environment variables – never committed.
 
 ---
 
-## Database schema (Supabase)
+## Legacy database schema (Supabase)
 
 ### Reports table
 
@@ -79,22 +82,16 @@ CREATE POLICY "View only approved stories" ON public.stories FOR SELECT USING (i
 Blocked names table (optional, used by worker)
 sql
 CREATE TABLE public.blocked_names (name TEXT PRIMARY KEY);
-Environment variables
+Environment variables and bindings
 Frontend (hardcoded in index.html – replace if you fork):
-
-SUPABASE_URL
-
-SUPABASE_ANON_KEY
 
 TURNSTILE_SITE_KEY
 
-Worker (set in Cloudflare Dashboard → Worker → Variables):
-
-SUPABASE_URL
-
-SUPABASE_SERVICE_ROLE_KEY
+Worker (set in Cloudflare Dashboard → Worker → Variables / Bindings):
 
 TURNSTILE_SECRET_KEY
+
+DB (Cloudflare D1 binding)
 
 CACHE_KV (KV namespace binding for caching)
 

--- a/index.html
+++ b/index.html
@@ -716,8 +716,7 @@
 }
     
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  <script src="https://js.hcaptcha.com/1/api.js" async defer></script>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
   <script src="mapdata.js?v=2026-04-24-3"></script>
   <script src="usmap.js?v=2026-04-24-4"></script>
   <script src="wmapdata.js?v=2026-04-25-1"></script>
@@ -1062,17 +1061,16 @@
 
           <div class="row">
             <div
-              id="report-hcaptcha"
-              class="h-captcha"
-              data-sitekey="1aaa310a-1942-4844-b7d6-7832ed34891c"
+              id="report-turnstile"
+              class="cf-turnstile"
+              data-sitekey="0x4AAAAAADCC51BDmfY6JgSc"
               data-theme="dark"
-              data-hcaptcha-type="challenge"
               data-size="normal"
-              data-callback="onHCaptchaSuccess"
-              data-expired-callback="onHCaptchaExpired"
-              data-error-callback="onHCaptchaError"
+              data-callback="onTurnstileSuccess"
+              data-expired-callback="onTurnstileExpired"
+              data-error-callback="onTurnstileError"
             ></div>
-            <p id="hcaptcha-warning" class="warning hidden">Please complete the CAPTCHA verification.</p>
+            <p id="turnstile-warning" class="warning hidden">Please complete the CAPTCHA verification.</p>
           </div>
 
           <p id="rate-warning" class="message error hidden">You have reached the limit of 3 submissions in the last hour. Please try again later.</p>
@@ -1108,14 +1106,14 @@
 </div>
     <div class="row">
       <div
-        id="story-hcaptcha"
-        class="h-captcha"
-        data-sitekey="1aaa310a-1942-4844-b7d6-7832ed34891c"
+        id="story-turnstile"
+        class="cf-turnstile"
+        data-sitekey="0x4AAAAAADCC51BDmfY6JgSc"
         data-theme="dark"
         data-size="normal"
-        data-callback="onStoryHCaptchaSuccess"
-        data-expired-callback="onStoryHCaptchaExpired"
-        data-error-callback="onStoryHCaptchaError"
+        data-callback="onStoryTurnstileSuccess"
+        data-expired-callback="onStoryTurnstileExpired"
+        data-error-callback="onStoryTurnstileError"
       ></div>
       <p id="story-turnstile-warning" class="warning hidden">Please complete the CAPTCHA.</p>
     </div>
@@ -1182,8 +1180,7 @@
       'pedo'
     ];
 
-    const SUPABASE_URL = 'https://cmmggaprguusffiphegy.supabase.co';
-    const SUPABASE_ANON_KEY = 'sb_publishable_G9Doh6gciyFVT1NDum55ZA_8ryL3fOw';
+    const API_BASE_URL = 'https://api.namehim.app';
     const MAX_BROWSE_FIELD_LENGTH = 30;
     const MAX_COUNTRY_LENGTH = 64;
     const MAX_COMMUNITY_POST_LENGTH = 1000;
@@ -1191,7 +1188,6 @@
     const RATE_LIMIT_STORAGE_KEY = 'submission_timestamps';
     const SUBMITTER_ID_KEY = 'submitter_id';
 
-    const supabaseClient = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
     const pageBrowse = document.getElementById('page-browse');
     const pageSubmit = document.getElementById('page-submit');
@@ -1207,7 +1203,7 @@
     const reportForm = document.getElementById('report-form');
     const submitBtn = document.getElementById('submit-btn');
     const rateWarning = document.getElementById('rate-warning');
-    const hcaptchaWarning = document.getElementById('hcaptcha-warning');
+    const turnstileWarning = document.getElementById('turnstile-warning');
     const categoryContainer = document.getElementById('category-checkboxes');
     const reportCount = document.getElementById('report-count');
     const countryField = document.getElementById('country');
@@ -1523,7 +1519,7 @@
         return true;
       }
       try {
-        const response = await fetch('https://api.namehim.app/filtered-reports');
+        const response = await fetch(`${API_BASE_URL}/filtered-reports`);
         if (!response.ok) throw new Error(`Worker returned ${response.status}`);
         const reports = await response.json();
         fullReportsList = sanitizeFetchedReports(reports);
@@ -2406,7 +2402,7 @@ function addStoryTimestamp() {
   if (selectedCategory) {
     params.set('category', selectedCategory);
   }
-  const WORKER_URL = `https://api.namehim.app/reports?${params.toString()}`;
+  const WORKER_URL = `${API_BASE_URL}/reports?${params.toString()}`;
 
   try {
     const response = await fetch(WORKER_URL);
@@ -2444,7 +2440,7 @@ function addStoryTimestamp() {
 
 // Original full fetch (kept for fallback)
 async function loadReportsFull() {
-  const WORKER_URL = 'https://api.namehim.app/filtered-reports';
+  const WORKER_URL = `${API_BASE_URL}/filtered-reports`;
   try {
     const response = await fetch(WORKER_URL);
     if (!response.ok) throw new Error(`Worker returned ${response.status}`);
@@ -2472,7 +2468,7 @@ async function loadReportsFull() {
 
 async function loadMapStats() {
   try {
-    const response = await fetch('https://api.namehim.app/stats');
+    const response = await fetch(`${API_BASE_URL}/stats`);
     if (!response.ok) throw new Error(`Stats endpoint returned ${response.status}`);
     const data = await response.json();
     stateCounts = data && data.stateCounts && typeof data.stateCounts === 'object' ? data.stateCounts : {};
@@ -2594,41 +2590,39 @@ async function loadMapStats() {
     async function loadApprovedStories(options = {}) {
       const storyId = options.storyId || null;
       storiesContainer.innerHTML = '<p>Loading stories...</p>';
-      let query = supabaseClient
-        .from('stories')
-        .select('id, title, content, created_at, category, admin_reply')
-        .eq('is_approved', true);
-      if (storyId) {
-        query = query.eq('id', storyId).limit(1);
-      } else {
-        query = query.order('created_at', { ascending: false });
-      }
-      const { data, error } = await query;
+      const params = new URLSearchParams();
+      if (storyId) params.set('id', storyId);
+      const storiesUrl = `${API_BASE_URL}/stories${params.toString() ? '?' + params.toString() : ''}`;
 
-      if (error) {
+      try {
+        const response = await fetch(storiesUrl);
+        if (!response.ok) throw new Error(`Stories endpoint returned ${response.status}`);
+        const data = await response.json();
+        const stories = data && Array.isArray(data.stories) ? data.stories : [];
+
+        if (!stories.length) {
+          approvedStories = [];
+          storiesContainer.innerHTML = storyId
+            ? '<p>Post not found. <a href="#/community">Back to all approved posts</a>.</p>'
+            : '<p>No approved stories yet. Check back soon.</p>';
+          return;
+        }
+
+        approvedStories = stories;
+        if (!storyId) {
+          applyStoryFilters();
+          return;
+        }
+
+        let html = '';
+        for (const story of stories) {
+          html += getStoryCardMarkup(story);
+        }
+        storiesContainer.innerHTML = html;
+      } catch (error) {
+        console.error('Failed to load stories:', error);
         storiesContainer.innerHTML = '<p>Error loading stories.</p>';
-        return;
       }
-
-      if (!data.length) {
-        approvedStories = [];
-        storiesContainer.innerHTML = storyId
-          ? '<p>Post not found. <a href="#/community">Back to all approved posts</a>.</p>'
-          : '<p>No approved stories yet. Check back soon.</p>';
-        return;
-      }
-
-      approvedStories = data;
-      if (!storyId) {
-        applyStoryFilters();
-        return;
-      }
-
-      let html = '';
-      for (const story of data) {
-        html += getStoryCardMarkup(story);
-      }
-      storiesContainer.innerHTML = html;
     }
 
     function updateCommunityViewFromRoute() {
@@ -2655,48 +2649,48 @@ async function loadMapStats() {
     }
 
 
-    let hcaptchaTokenValue = '';
-    let storyHcaptchaTokenValue = '';
+    let turnstileTokenValue = '';
+    let storyTurnstileTokenValue = '';
 
-    window.onHCaptchaSuccess = function onHCaptchaSuccess(token) {
-      hcaptchaTokenValue = token || '';
-      if (hcaptchaWarning) hcaptchaWarning.classList.add('hidden');
+    window.onTurnstileSuccess = function onTurnstileSuccess(token) {
+      turnstileTokenValue = token || '';
+      if (turnstileWarning) turnstileWarning.classList.add('hidden');
     };
 
-    window.onHCaptchaExpired = function onHCaptchaExpired() {
-      hcaptchaTokenValue = '';
+    window.onTurnstileExpired = function onTurnstileExpired() {
+      turnstileTokenValue = '';
     };
 
-    window.onHCaptchaError = function onHCaptchaError() {
-      hcaptchaTokenValue = '';
+    window.onTurnstileError = function onTurnstileError() {
+      turnstileTokenValue = '';
     };
-    window.onStoryHCaptchaSuccess = function onStoryHCaptchaSuccess(token) {
-      storyHcaptchaTokenValue = token || '';
+    window.onStoryTurnstileSuccess = function onStoryTurnstileSuccess(token) {
+      storyTurnstileTokenValue = token || '';
       if (storyTurnstileWarning) storyTurnstileWarning.classList.add('hidden');
     };
-    window.onStoryHCaptchaExpired = function onStoryHCaptchaExpired() {
-      storyHcaptchaTokenValue = '';
+    window.onStoryTurnstileExpired = function onStoryTurnstileExpired() {
+      storyTurnstileTokenValue = '';
     };
-    window.onStoryHCaptchaError = function onStoryHCaptchaError() {
-      storyHcaptchaTokenValue = '';
+    window.onStoryTurnstileError = function onStoryTurnstileError() {
+      storyTurnstileTokenValue = '';
     };
 
-    function getHCaptchaToken() {
-      if (hcaptchaTokenValue) return hcaptchaTokenValue;
+    function getTurnstileToken() {
+      if (turnstileTokenValue) return turnstileTokenValue;
 
-      if (window.hcaptcha && typeof window.hcaptcha.getResponse === 'function') {
-        const token = window.hcaptcha.getResponse();
+      if (window.turnstile && typeof window.turnstile.getResponse === 'function') {
+        const token = window.turnstile.getResponse();
         if (token) return token;
       }
 
-      const tokenField = document.querySelector('[name="h-captcha-response"]');
+      const tokenField = document.querySelector('[name="cf-turnstile-response"]');
       return tokenField && tokenField.value ? tokenField.value : '';
     }
 
-    function resetHCaptchaWidget() {
-      hcaptchaTokenValue = '';
-      if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') {
-        window.hcaptcha.reset();
+    function resetTurnstileWidget() {
+      turnstileTokenValue = '';
+      if (window.turnstile && typeof window.turnstile.reset === 'function') {
+        window.turnstile.reset();
       }
     }
 
@@ -2711,10 +2705,10 @@ async function loadMapStats() {
       showStoryFormBtn.classList.add('hidden');
       showStoryFormBtn.setAttribute('aria-expanded', 'true');
 
-      if (!window.hcaptcha || typeof window.hcaptcha.reset !== 'function') return;
-      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      if (!window.turnstile || typeof window.turnstile.reset !== 'function') return;
+      const storyTokenField = document.querySelector('#story-form [name="cf-turnstile-response"]');
       if (!storyTokenField || !storyTokenField.value) return;
-      window.hcaptcha.reset();
+      window.turnstile.reset();
     }
 
     async function submitStory(event) {
@@ -2743,12 +2737,12 @@ async function loadMapStats() {
       let category = document.getElementById('story-category').value;
       if (!category) category = 'General';
 
-      let token = storyHcaptchaTokenValue || '';
-      const storyTokenField = document.querySelector('#story-form [name="h-captcha-response"]');
+      let token = storyTurnstileTokenValue || '';
+      const storyTokenField = document.querySelector('#story-form [name="cf-turnstile-response"]');
       if (storyTokenField && storyTokenField.value) {
         token = storyTokenField.value;
-      } else if (window.hcaptcha && typeof window.hcaptcha.getResponse === 'function') {
-        token = window.hcaptcha.getResponse();
+      } else if (window.turnstile && typeof window.turnstile.getResponse === 'function') {
+        token = window.turnstile.getResponse();
       }
 
       if (!token) {
@@ -2759,7 +2753,7 @@ async function loadMapStats() {
       storySubmitBtn.disabled = true;
 
       try {
-        const response = await fetch('https://api.namehim.app/submit-story', {
+        const response = await fetch(`${API_BASE_URL}/submit-story`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
@@ -2767,7 +2761,7 @@ async function loadMapStats() {
             content,
             category,
             submitter_uuid: localStorage.getItem('submitter_id'),
-            hcaptchaToken: token
+            turnstileToken: token
           })
         });
         const result = await response.json();
@@ -2779,8 +2773,8 @@ async function loadMapStats() {
         storyMessage.textContent = 'Thank you. Your story has been submitted for review.';
         storyMessage.className = 'message success';
         storyForm.reset();
-        storyHcaptchaTokenValue = '';
-        if (window.hcaptcha && typeof window.hcaptcha.reset === 'function') window.hcaptcha.reset();
+        storyTurnstileTokenValue = '';
+        if (window.turnstile && typeof window.turnstile.reset === 'function') window.turnstile.reset();
         if (window.location.hash === '#/community') loadApprovedStories();
       } catch (error) {
         console.error('Story submission error:', error);
@@ -2801,12 +2795,12 @@ async function loadMapStats() {
     submitMessage.textContent = 'Report submitted successfully.';
     submitMessage.className = 'message success';
     reportForm.reset();
-    resetHCaptchaWidget();
+    resetTurnstileWidget();
     return;
     }
       submitMessage.textContent = '';
       submitMessage.className = 'message';
-      hcaptchaWarning.classList.add('hidden');
+      turnstileWarning.classList.add('hidden');
 
       if (updateRateLimitUI()) {
         submitMessage.textContent = 'Rate limit reached. Please wait before submitting again.';
@@ -2814,9 +2808,9 @@ async function loadMapStats() {
         return;
       }
 
-      const token = getHCaptchaToken();
+      const token = getTurnstileToken();
       if (!token) {
-        hcaptchaWarning.classList.remove('hidden');
+        turnstileWarning.classList.remove('hidden');
         return;
       }
 
@@ -2827,7 +2821,7 @@ async function loadMapStats() {
         country: sanitizeReportText(document.getElementById('country').value, MAX_BROWSE_FIELD_LENGTH),
         categories: getSelectedCategories(),
         submitter_uuid: getOrCreateSubmitterId(),
-        hcaptchaToken: token
+        turnstileToken: token
       };
 
       // Validation (keep your existing checks)
@@ -2876,7 +2870,7 @@ async function loadMapStats() {
       submitBtn.disabled = true;
 
       try {
-        const response = await fetch('https://api.namehim.app/submit', {
+        const response = await fetch(`${API_BASE_URL}/submit`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload)
@@ -2891,14 +2885,14 @@ async function loadMapStats() {
         reportForm.reset();
         renderStateField();
         populateBrowseStateSelect();
-        resetHCaptchaWidget();
+        resetTurnstileWidget();
         submitMessage.textContent = 'Report submitted successfully.';
         submitMessage.className = 'message success';
         await loadReports();
         window.location.hash = '#/browse';
       } catch (error) {
         console.error('Submission error:', error);
-        resetHCaptchaWidget();
+        resetTurnstileWidget();
         submitMessage.textContent = error.message;
         submitMessage.className = 'message error';
       } finally {
@@ -2938,16 +2932,17 @@ async function loadMapStats() {
     // button.disabled = true;
     //
     // try {
-    //   const { error } = await supabaseClient
-    //     .from('report_flags')
-    //     .insert({
+    //   const response = await fetch(`${API_BASE_URL}/report-flag`, {
+    //     method: 'POST',
+    //     headers: { 'Content-Type': 'application/json' },
+    //     body: JSON.stringify({
     //       report_id: parseInt(reportId, 10),
     //       reason: reason,
     //       flagged_by: submitterId
-    //     });
+    //     })
+    //   });
     //
-    //   if (error) {
-    //     console.error(error);
+    //   if (!response.ok) {
     //     alert('Could not flag entry. Please try again later.');
     //   } else {
     //     alert('Entry #' + reportId + ' has been flagged for review.\nThank you for your report.');

--- a/worker/index.js
+++ b/worker/index.js
@@ -58,10 +58,10 @@ export default {
       let reports;
       if (cached && Array.isArray(cached)) {
         reports = cached;
-        ctx.waitUntil(refreshIfStale(env));
+        if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
       } else {
         reports = await fetchAllReportsFromD1(env);
-        if (reports && reports.length && env.CACHE_KV) {
+        if (Array.isArray(reports) && env.CACHE_KV) {
           await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
           await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
         }
@@ -100,10 +100,10 @@ export default {
       let reports;
       if (cached && Array.isArray(cached)) {
         reports = cached;
-        ctx.waitUntil(refreshIfStale(env));
+        if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
       } else {
         reports = await fetchAllReportsFromD1(env);
-        if (reports && reports.length && env.CACHE_KV) {
+        if (Array.isArray(reports) && env.CACHE_KV) {
           await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
           await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
         }
@@ -133,11 +133,30 @@ export default {
       });
     }
 
+    // GET /stories – approved community stories from D1
+    if (request.method === "GET" && url.pathname === "/stories") {
+      const storyId = url.searchParams.get("id");
+      try {
+        const stories = await fetchApprovedStoriesFromD1(env, storyId);
+        return new Response(JSON.stringify({ stories }), {
+          status: 200,
+          headers: { "Content-Type": "application/json", ...corsHeaders() }
+        });
+      } catch (err) {
+        console.error("Stories fetch failed:", err);
+        return errorResponse("Unable to load stories", 500);
+      }
+    }
+
     if (request.method === "POST" && url.pathname === "/submit") {
       return handleSubmitReport(request, env);
     }
     if (request.method === "POST" && url.pathname === "/submit-story") {
       return handleSubmitStory(request, env);
+    }
+
+    if (request.method !== "GET" || (url.pathname !== "/filtered-reports" && url.pathname !== "/")) {
+      return new Response(JSON.stringify({ error: "Not found" }), { status: 404, headers: corsHeaders() });
     }
 
     // ----- GET /filtered-reports (full list, legacy) -----
@@ -147,7 +166,7 @@ export default {
     } catch (e) { console.error("KV read error:", e); }
 
     if (cached && Array.isArray(cached)) {
-      ctx.waitUntil(refreshIfStale(env));
+      if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
       const preparedReports = sortAndFilterReports(cached, {
         sortBy: url.searchParams.get("sortBy"),
         sortDirection: url.searchParams.get("sortDirection"),
@@ -165,7 +184,7 @@ export default {
 
     try {
       const reports = await fetchAllReportsFromD1(env);
-      if (reports && reports.length) {
+      if (Array.isArray(reports)) {
         const preparedReports = sortAndFilterReports(reports, {
           sortBy: url.searchParams.get("sortBy"),
           sortDirection: url.searchParams.get("sortDirection"),
@@ -221,26 +240,16 @@ async function handleSubmitReport(request, env) {
   if (blockedSet.has(payload.name.toLowerCase()))
     return errorResponse("The name you entered is not allowed for submission.", 400);
 
-  const token = payload.hcaptchaToken;
+  const token = payload.turnstileToken;
   if (!token) return errorResponse("CAPTCHA token missing", 400);
 
-  const verifyRes = await fetch("https://api.hcaptcha.com/siteverify", {
-    method: "POST",
-    body: new URLSearchParams({
-      secret: env.HCAPTCHA_SECRET,
-      response: token,
-      remoteip: ip || ""
-    }),
-    headers: { "Content-Type": "application/x-www-form-urlencoded" }
-  });
-  const verifyData = await verifyRes.json();
-  if (!verifyData.success) {
-    const errorCodes = Array.isArray(verifyData["error-codes"]) ? verifyData["error-codes"].join(", ") : "unknown";
-    console.error("hCaptcha verify failed (/submit):", errorCodes);
-    return errorResponse(`Invalid CAPTCHA (${errorCodes})`, 400);
+  const verifyResult = await verifyTurnstileToken(token, env, ip);
+  if (!verifyResult.success) {
+    console.error("Turnstile verify failed (/submit):", verifyResult.errorCodes);
+    return errorResponse("Invalid CAPTCHA", 400);
   }
 
-  const { hcaptchaToken, ...reportData } = payload;
+  const { turnstileToken, ...reportData } = payload;
   const db = env.DB;
   const categoriesJson = JSON.stringify(reportData.categories);
   const insertStmt = await db.prepare(`
@@ -292,39 +301,31 @@ async function handleSubmitStory(request, env) {
   let payload;
   try { payload = await request.json(); } catch (err) { return errorResponse("Invalid JSON", 400); }
 
-  const { title, content, submitter_uuid, hcaptchaToken } = payload;
+  const { title, content, category, submitter_uuid, turnstileToken } = payload;
   if (!content || typeof content !== "string") return errorResponse("Missing story content", 400);
   if (content.length > 1000) return errorResponse("Story too long", 400);
-  if (!hcaptchaToken) return errorResponse("CAPTCHA token missing", 400);
+  if (!turnstileToken) return errorResponse("CAPTCHA token missing", 400);
 
-  const verifyRes = await fetch("https://api.hcaptcha.com/siteverify", {
-    method: "POST",
-    body: new URLSearchParams({
-      secret: env.HCAPTCHA_SECRET,
-      response: hcaptchaToken,
-      remoteip: ip || ""
-    }),
-    headers: { "Content-Type": "application/x-www-form-urlencoded" }
-  });
-  const verifyData = await verifyRes.json();
-  if (!verifyData.success) {
-    const errorCodes = Array.isArray(verifyData["error-codes"]) ? verifyData["error-codes"].join(", ") : "unknown";
-    console.error("hCaptcha verify failed (/submit-story):", errorCodes);
-    return errorResponse(`Invalid CAPTCHA (${errorCodes})`, 400);
+  const verifyResult = await verifyTurnstileToken(turnstileToken, env, ip);
+  if (!verifyResult.success) {
+    console.error("Turnstile verify failed (/submit-story):", verifyResult.errorCodes);
+    return errorResponse("Invalid CAPTCHA", 400);
   }
 
   const db = env.DB;
+  if (!db) throw new Error("D1 binding DB is not configured");
+  const storyColumns = await getTableColumns(db, "stories");
+  const insertColumns = ["title", "content", "submitter_uuid", "is_approved", "created_at"];
+  const insertValues = [title || null, content, submitter_uuid || null, 0, new Date().toISOString()];
+  if (storyColumns.has("category")) {
+    insertColumns.push("category");
+    insertValues.push(category || "General");
+  }
+  const placeholders = insertColumns.map(() => "?").join(", ");
   const insertStmt = await db.prepare(`
-    INSERT INTO stories (title, content, submitter_uuid, is_approved, created_at, category)
-    VALUES (?, ?, ?, ?, ?, ?)
-  `).bind(
-    title || null,
-    content,
-    submitter_uuid || null,
-    0,
-    new Date().toISOString(),
-    "General"
-  );
+    INSERT INTO stories (${insertColumns.join(", ")})
+    VALUES (${placeholders})
+  `).bind(...insertValues);
   
   try {
     const res = await insertStmt.run();
@@ -336,6 +337,30 @@ async function handleSubmitStory(request, env) {
   return new Response(JSON.stringify({ success: true }), { status: 200, headers: corsHeaders() });
 }
 __name(handleSubmitStory, "handleSubmitStory");
+
+async function verifyTurnstileToken(token, env, ip) {
+  if (!env.TURNSTILE_SECRET_KEY) {
+    return { success: false, errorCodes: "missing-secret" };
+  }
+
+  const body = new URLSearchParams({
+    secret: env.TURNSTILE_SECRET_KEY,
+    response: token
+  });
+  if (ip) body.set("remoteip", ip);
+
+  const verifyRes = await fetch("https://challenges.cloudflare.com/turnstile/v0/siteverify", {
+    method: "POST",
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" }
+  });
+  const verifyData = await verifyRes.json();
+  return {
+    success: Boolean(verifyData.success),
+    errorCodes: Array.isArray(verifyData["error-codes"]) ? verifyData["error-codes"].join(", ") : "unknown"
+  };
+}
+__name(verifyTurnstileToken, "verifyTurnstileToken");
 
 function corsHeaders() {
   return {
@@ -413,26 +438,61 @@ async function getBlockedNamesSet(env) {
   // Try to get from KV cache
   let blockedSet = null;
   try {
-    const cached = await env.CACHE_KV.get(BLOCKED_NAMES_KEY);
-    if (cached) blockedSet = new Set(JSON.parse(cached));
+    if (env.CACHE_KV) {
+      const cached = await env.CACHE_KV.get(BLOCKED_NAMES_KEY);
+      if (cached) blockedSet = new Set(JSON.parse(cached));
+    }
   } catch (e) { console.error("KV blocked names read error:", e); }
   if (blockedSet) return blockedSet;
 
   // Fetch from D1
   const db = env.DB;
+  if (!db) throw new Error("D1 binding DB is not configured");
   const { results } = await db.prepare("SELECT name FROM blocked_names").all();
-  const names = results.map(row => row.name.toLowerCase());
+  const names = (results || []).map(row => String(row.name || "").toLowerCase()).filter(Boolean);
   blockedSet = new Set(names);
   // Cache for 10 minutes (600 seconds)
   try {
-    await env.CACHE_KV.put(BLOCKED_NAMES_KEY, JSON.stringify(Array.from(blockedSet)), { expirationTtl: 600 });
+    if (env.CACHE_KV) await env.CACHE_KV.put(BLOCKED_NAMES_KEY, JSON.stringify(Array.from(blockedSet)), { expirationTtl: 600 });
   } catch (e) { console.error("KV blocked names write error:", e); }
   return blockedSet;
 }
 __name(getBlockedNamesSet, "getBlockedNamesSet");
 
+async function getTableColumns(db, tableName) {
+  const { results } = await db.prepare(`PRAGMA table_info(${tableName})`).all();
+  return new Set((results || []).map((column) => column.name));
+}
+__name(getTableColumns, "getTableColumns");
+
+async function fetchApprovedStoriesFromD1(env, storyId = null) {
+  const db = env.DB;
+  if (!db) throw new Error("D1 binding DB is not configured");
+
+  const storyColumns = await getTableColumns(db, "stories");
+  const selectColumns = ["id", "title", "content", "created_at"];
+  if (storyColumns.has("category")) selectColumns.push("category");
+  if (storyColumns.has("admin_reply")) selectColumns.push("admin_reply");
+
+  const baseSelect = `SELECT ${selectColumns.join(", ")} FROM stories WHERE is_approved = 1`;
+  const stmt = storyId
+    ? db.prepare(`${baseSelect} AND id = ? ORDER BY created_at DESC LIMIT 1`).bind(storyId)
+    : db.prepare(`${baseSelect} ORDER BY created_at DESC`);
+  const { results } = await stmt.all();
+  return (results || []).map((row) => ({
+    id: row.id,
+    title: row.title,
+    content: row.content,
+    created_at: row.created_at,
+    category: row.category || "General",
+    admin_reply: row.admin_reply || ""
+  }));
+}
+__name(fetchApprovedStoriesFromD1, "fetchApprovedStoriesFromD1");
+
 async function fetchAllReportsFromD1(env) {
   const db = env.DB;
+  if (!db) throw new Error("D1 binding DB is not configured");
   const { results } = await db.prepare("SELECT id, name, city, state, country, categories, created_at, submitter_uuid FROM reports ORDER BY id DESC").all();
   if (!results || !results.length) return [];
 
@@ -442,7 +502,7 @@ async function fetchAllReportsFromD1(env) {
   // Filter reports and parse categories
   const filtered = [];
   for (const row of results) {
-    if (blockedSet.has(row.name.toLowerCase())) continue;
+    if (blockedSet.has(String(row.name || "").toLowerCase())) continue;
     let categories = [];
     try { categories = JSON.parse(row.categories); } catch(e) { categories = []; }
     filtered.push({

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -11,3 +11,12 @@ name = "RATELIMITER"
 type = "ratelimit"
 namespace_id = "1001"
 simple = { limit = 3, period = 60 }
+
+
+# D1 database binding required by worker/index.js (env.DB).
+# The database_id is account-specific; if this binding is not already configured
+# in the Cloudflare dashboard, uncomment this block and fill in the D1 UUID.
+# [[d1_databases]]
+# binding = "DB"
+# database_name = "nameham-db"
+# database_id = "<your-d1-database-uuid>"


### PR DESCRIPTION
### Motivation
- Move the site off direct Supabase access to a Cloudflare D1-backed Worker API so the frontend always reads/writes through the worker and shares the same data source.
- Replace broken hCaptcha integration with Cloudflare Turnstile (server-side verification) so submissions work again.
- Add robust handling for optional story columns and caching to ensure the Worker works with existing/variant D1 schemas.

### Description
- Worker (`worker/index.js`): added `verifyTurnstileToken`, `getTableColumns`, and `fetchApprovedStoriesFromD1` helpers; switched report/story submission and fetch logic to use the D1 binding `env.DB`; switched CAPTCHA verification from hCaptcha to Turnstile; hardened KV checks and `ctx.waitUntil` usage; added a `/stories` endpoint and guarded legacy `/filtered-reports` route.
- Frontend (`index.html`): removed hCaptcha script/widgets, added Cloudflare Turnstile script/widgets, changed client token names to `turnstileToken`, centralized worker API base via `API_BASE_URL`, removed direct Supabase client usage for loading approved stories and now fetches `/stories` from the worker.
- Config/docs: added a commented hint to `worker/wrangler.toml` describing the required D1 binding (`DB`) and updated `README.md` to reflect D1 + Turnstile usage and new endpoints.
- Misc: made the stories insert tolerant of an optional `category` column and the story select tolerant of optional `category`/`admin_reply` columns; improved defensive checks when KV or D1 bindings are missing.

### Testing
- Ran JavaScript syntax checks with `node --check` on inlined frontend scripts and the worker file, both succeeded.
- Verified the repository no longer references hCaptcha or Supabase client with a project-wide `rg` search, succeeded.
- Executed a small mock integration test `node /tmp/test-worker.mjs` that instantiates the worker with a mock `DB.prepare` and validated `GET /reports` and `GET /stories` responses, which passed.
- Served the frontend locally with `python3 -m http.server` and fetched headers with `curl -I`, which returned `200 OK` for `index.html` (sanity check), succeeded.
- Attempted `npx wrangler d1 list --json` to inspect Cloudflare D1 from this environment, but it failed due to an npm registry `403 Forbidden` error (environment/network limitation), so the actual Cloudflare `database_id` could not be discovered here.

If the Worker is deployed but still not reading your D1, ensure the Cloudflare Worker has a D1 binding named `DB` configured (the `database_id` must be set in the Cloudflare dashboard or `wrangler.toml` for your account).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff22b96e8832fa5df272b532eb858)