### PR TITLE
Update community header to show approved community post count

### DIFF
--- a/index.html
+++ b/index.html
@@ -1939,6 +1939,7 @@ async function filterReportsByState(stateFullName) {
   });
 
   updateBrowseViewFromRoute();
+  syncReportCountHeaderForRoute();
 
   if (route === '#/browse' && !getReportIdFromUrl()) {
     loadReports(DEFAULT_BROWSE_PAGE);
@@ -2024,34 +2025,79 @@ function addStoryTimestamp() {
       return parsedTotal.toLocaleString('en-US');
     }
 
+    let latestReportTotal = null;
+    let latestCommunityPostTotal = null;
+
+    function isCommunityRouteActive() {
+      return getCurrentRoute() === '#/community';
+    }
+
     function updateReportCount(total) {
-      reportCount.textContent = formatReportTotal(total) + ' reports and counting...';
+      latestReportTotal = Number(total) || 0;
+      if (!isCommunityRouteActive()) {
+        reportCount.textContent = formatReportTotal(latestReportTotal) + ' reports and counting...';
+      }
+    }
+
+    function updateCommunityPostCount(total) {
+      latestCommunityPostTotal = Number(total) || 0;
+      if (isCommunityRouteActive()) {
+        reportCount.textContent = formatReportTotal(latestCommunityPostTotal) + ' community posts shared';
+      }
     }
 
     const loadingDots = ['.', '..', '...'];
     let loadingDotIndex = 0;
     let reportCountLoadingInterval = null;
+    let reportCountLoadingContext = null;
 
-    function startReportCountLoadingAnimation() {
-      if (!reportCount || reportCountLoadingInterval) {
+    function startReportCountLoadingAnimation(label = 'Loading reports and counting', context = 'reports') {
+      if (!reportCount) {
         return;
       }
 
-      reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      stopReportCountLoadingAnimation();
+      reportCountLoadingContext = context;
+      reportCount.textContent = label + loadingDots[loadingDotIndex];
       reportCountLoadingInterval = setInterval(() => {
         loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
-        reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+        reportCount.textContent = label + loadingDots[loadingDotIndex];
       }, 1000);
     }
 
-    function stopReportCountLoadingAnimation() {
+    function stopReportCountLoadingAnimation(context = null) {
+      if (context && reportCountLoadingContext && context !== reportCountLoadingContext) {
+        return;
+      }
       if (!reportCountLoadingInterval) {
+        reportCountLoadingContext = null;
+        loadingDotIndex = 0;
         return;
       }
 
       clearInterval(reportCountLoadingInterval);
       reportCountLoadingInterval = null;
+      reportCountLoadingContext = null;
       loadingDotIndex = 0;
+    }
+
+    function syncReportCountHeaderForRoute() {
+      if (isCommunityRouteActive()) {
+        if (latestCommunityPostTotal === null) {
+          startReportCountLoadingAnimation('Loading number of community posts', 'community');
+        } else {
+          stopReportCountLoadingAnimation('community');
+          updateCommunityPostCount(latestCommunityPostTotal);
+        }
+        return;
+      }
+
+      if (latestReportTotal === null) {
+        startReportCountLoadingAnimation('Loading reports and counting', 'reports');
+      } else {
+        stopReportCountLoadingAnimation('reports');
+        updateReportCount(latestReportTotal);
+      }
     }
 
     function formatTimestamp(timestamp) {
@@ -2371,7 +2417,9 @@ function addStoryTimestamp() {
     async function loadReports(page = 1) {
   browseMessage.textContent = 'Loading reports...';
   browseMessage.className = 'message';
-  startReportCountLoadingAnimation();
+  if (!isCommunityRouteActive()) {
+    startReportCountLoadingAnimation('Loading reports and counting', 'reports');
+  }
 
   const limit = REPORTS_PER_PAGE;
   const { sortBy, sortDirection } = parseSortSelection(reportSort && reportSort.value);
@@ -2575,6 +2623,7 @@ async function loadMapStats() {
     async function loadApprovedStories(options = {}) {
       const storyId = options.storyId || null;
       storiesContainer.innerHTML = '<p>Loading stories...</p>';
+      startReportCountLoadingAnimation('Loading number of community posts', 'community');
       const params = new URLSearchParams();
       if (storyId) params.set('id', storyId);
       params.set('refresh', '1');
@@ -2586,6 +2635,11 @@ async function loadMapStats() {
         if (!response.ok) throw new Error(`Stories endpoint returned ${response.status}`);
         const data = await response.json();
         const stories = data && Array.isArray(data.stories) ? data.stories : [];
+        const approvedPostCount = Number.isFinite(Number(data && data.approvedCount))
+          ? Number(data.approvedCount)
+          : (Number.isFinite(Number(data && data.total)) ? Number(data.total) : (storyId && latestCommunityPostTotal !== null ? latestCommunityPostTotal : stories.length));
+        stopReportCountLoadingAnimation('community');
+        updateCommunityPostCount(approvedPostCount);
 
         if (!stories.length) {
           approvedStories = [];
@@ -2608,6 +2662,10 @@ async function loadMapStats() {
         storiesContainer.innerHTML = html;
       } catch (error) {
         console.error('Failed to load stories:', error);
+        stopReportCountLoadingAnimation('community');
+        if (isCommunityRouteActive()) {
+          reportCount.textContent = 'Unable to load community posts.';
+        }
         storiesContainer.innerHTML = '<p>Error loading stories.</p>';
       }
     }

--- a/worker/index.js
+++ b/worker/index.js
@@ -140,8 +140,8 @@ export default {
     if (request.method === "GET" && url.pathname === "/stories") {
       const storyId = url.searchParams.get("id");
       try {
-        const stories = await fetchApprovedStoriesFromD1(env, storyId);
-        return new Response(JSON.stringify({ stories }), {
+        const { stories, approvedCount } = await fetchApprovedStoriesFromD1(env, storyId);
+        return new Response(JSON.stringify({ stories, approvedCount, total: approvedCount }), {
           status: 200,
           headers: { "Content-Type": "application/json", ...corsHeaders() }
         });
@@ -558,11 +558,15 @@ async function fetchApprovedStoriesFromD1(env, storyId = null) {
   const orderBy = createdAtColumn ? `${createdAtColumn} DESC` : `${idColumn} DESC`;
 
   const baseSelect = `SELECT ${selectColumns.join(", ")} FROM stories WHERE ${approvalFilter}`;
+  const countStmt = db.prepare(`SELECT COUNT(*) AS approved_count FROM stories WHERE ${approvalFilter}`);
+  const countRow = await countStmt.first();
+  const approvedCount = Number(countRow && countRow.approved_count) || 0;
+
   const stmt = storyId
     ? db.prepare(`${baseSelect} AND ${idColumn} = ? ORDER BY ${orderBy} LIMIT 1`).bind(storyId)
     : db.prepare(`${baseSelect} ORDER BY ${orderBy}`);
   const { results } = await stmt.all();
-  return (results || []).map((row) => ({
+  const stories = (results || []).map((row) => ({
     id: row.id,
     title: row.title,
     content: row.content,
@@ -570,6 +574,7 @@ async function fetchApprovedStoriesFromD1(env, storyId = null) {
     category: row.category || "General",
     admin_reply: row.admin_reply || ""
   }));
+  return { stories, approvedCount };
 }
 __name(fetchApprovedStoriesFromD1, "fetchApprovedStoriesFromD1");
 


### PR DESCRIPTION
### Motivation
- Make the site header show a community‑focused loading label while the Community page is loading and then display the number of approved community posts once loaded.
- Ensure the header count reads the authoritative approved‑posts total from the worker so the header reflects `is_approved` rows only.

### Description
- Added `latestReportTotal` and `latestCommunityPostTotal` state and new functions `updateCommunityPostCount`, `isCommunityRouteActive`, and `syncReportCountHeaderForRoute` in `index.html` to coordinate header text based on the active route and available counts.
- Reworked the loading animation to accept a `label` and `context` and to avoid report-loading animation overwriting the community header by tracking `reportCountLoadingContext` and gating start/stop calls.
- Modified `loadApprovedStories` in `index.html` to start the community loading label, read `approvedCount` (with fallbacks) from the `/stories` response, and update the header to `'<n> community posts shared'` after load or show an error message if the count fails to load.
- Updated the worker `GET /stories` handler and `fetchApprovedStoriesFromD1` in `worker/index.js` to return `{ stories, approvedCount, total: approvedCount }` where `approvedCount` is computed using the same approval filter (`is_approved` / `approved`) so the frontend receives the approved stories count.

### Testing
- `node --check worker/index.js` — succeeded.
- `node --check /tmp/namehim-index-script.js` (extracted page script syntax check) — succeeded.
- `git diff --check` — succeeded.
- Playwright/browser screenshot automation attempt failed because Playwright/browser tooling was not available in the environment, so end-to-end browser tests were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200a636eac832f9021105aa5605413)