### PR TITLE
Fix report API stale cache fallback and remove frontend cache-busters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1502,7 +1502,7 @@
         return true;
       }
       try {
-        const response = await fetch(`${API_BASE_URL}/filtered-reports?refresh=1&t=${Date.now()}`);
+        const response = await fetch(`${API_BASE_URL}/filtered-reports`);
         if (!response.ok) throw new Error(`Worker returned ${response.status}`);
         const reports = await response.json();
         fullReportsList = sanitizeFetchedReports(reports);
@@ -2385,8 +2385,6 @@ function addStoryTimestamp() {
   if (selectedCategory) {
     params.set('category', selectedCategory);
   }
-  params.set('refresh', '1');
-  params.set('t', String(Date.now()));
   const WORKER_URL = `${API_BASE_URL}/reports?${params.toString()}`;
 
   try {
@@ -2425,7 +2423,7 @@ function addStoryTimestamp() {
 
 // Original full fetch (kept for fallback)
 async function loadReportsFull() {
-  const WORKER_URL = `${API_BASE_URL}/filtered-reports?refresh=1&t=${Date.now()}`;
+  const WORKER_URL = `${API_BASE_URL}/filtered-reports`;
   try {
     const response = await fetch(WORKER_URL);
     if (!response.ok) throw new Error(`Worker returned ${response.status}`);
@@ -2453,7 +2451,7 @@ async function loadReportsFull() {
 
 async function loadMapStats() {
   try {
-    const response = await fetch(`${API_BASE_URL}/stats?refresh=1&t=${Date.now()}`);
+    const response = await fetch(`${API_BASE_URL}/stats`);
     if (!response.ok) throw new Error(`Stats endpoint returned ${response.status}`);
     const data = await response.json();
     stateCounts = data && data.stateCounts && typeof data.stateCounts === 'object' ? data.stateCounts : {};

--- a/worker/index.js
+++ b/worker/index.js
@@ -50,25 +50,8 @@ export default {
       const sortBy = normalizeSortBy(url.searchParams.get("sortBy"));
       const sortDirection = normalizeSortDirection(url.searchParams.get("sortDirection"));
       const category = normalizeCategoryFilter(url.searchParams.get("category"));
-      const bypassCache = shouldBypassCache(url);
+      const reports = await getReportsForRead(env, ctx, { bypassCache: shouldBypassCache(url) });
 
-      let cached = null;
-      try {
-        if (!bypassCache && env.CACHE_KV) cached = await env.CACHE_KV.get(CACHE_KEY, "json");
-      } catch (e) { console.error("KV read error:", e); }
-      
-      let reports;
-      if (cached && Array.isArray(cached)) {
-        reports = cached;
-        if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
-      } else {
-        reports = await fetchAllReportsFromD1(env);
-        if (Array.isArray(reports) && env.CACHE_KV) {
-          await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
-          await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
-        }
-      }
-      
       if (!reports) {
         return new Response(JSON.stringify({ error: "Service unavailable" }), { status: 503, headers: corsHeaders() });
       }
@@ -94,24 +77,8 @@ export default {
 
     // GET /stats – aggregated counts for maps
     if (request.method === "GET" && url.pathname === "/stats") {
-      const bypassCache = shouldBypassCache(url);
-      let cached = null;
-      try {
-        if (!bypassCache && env.CACHE_KV) cached = await env.CACHE_KV.get(CACHE_KEY, "json");
-      } catch (e) { console.error("KV read error:", e); }
-      
-      let reports;
-      if (cached && Array.isArray(cached)) {
-        reports = cached;
-        if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
-      } else {
-        reports = await fetchAllReportsFromD1(env);
-        if (Array.isArray(reports) && env.CACHE_KV) {
-          await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
-          await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
-        }
-      }
-      
+      const reports = await getReportsForRead(env, ctx, { bypassCache: shouldBypassCache(url) });
+
       if (!reports) {
         return new Response(JSON.stringify({ error: "Service unavailable" }), { status: 503, headers: corsHeaders() });
       }
@@ -163,15 +130,9 @@ export default {
     }
 
     // ----- GET /filtered-reports (full list, legacy) -----
-    const bypassCache = shouldBypassCache(url);
-    let cached = null;
-    try {
-      if (!bypassCache && env.CACHE_KV) cached = await env.CACHE_KV.get(CACHE_KEY, "json");
-    } catch (e) { console.error("KV read error:", e); }
-
-    if (cached && Array.isArray(cached)) {
-      if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
-      const preparedReports = sortAndFilterReports(cached, {
+    const reports = await getReportsForRead(env, ctx, { bypassCache: shouldBypassCache(url) });
+    if (Array.isArray(reports)) {
+      const preparedReports = sortAndFilterReports(reports, {
         sortBy: url.searchParams.get("sortBy"),
         sortDirection: url.searchParams.get("sortDirection"),
         category: url.searchParams.get("category")
@@ -186,34 +147,10 @@ export default {
       });
     }
 
-    try {
-      const reports = await fetchAllReportsFromD1(env);
-      if (Array.isArray(reports)) {
-        const preparedReports = sortAndFilterReports(reports, {
-          sortBy: url.searchParams.get("sortBy"),
-          sortDirection: url.searchParams.get("sortDirection"),
-          category: url.searchParams.get("category")
-        });
-        if (env.CACHE_KV) {
-          await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
-          await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
-        }
-        return new Response(JSON.stringify(preparedReports), {
-          status: 200,
-          headers: {
-            "Content-Type": "application/json",
-            "Access-Control-Allow-Origin": "https://namehim.app"
-          }
-        });
-      }
-    } catch (err) {
-      console.error("Initial fetch failed:", err);
-    }
-
-      return new Response(JSON.stringify({ error: "Service temporarily unavailable. Please try again in a minute." }), {
-        status: 503,
-        headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://namehim.app" }
-      });
+    return new Response(JSON.stringify({ error: "Service temporarily unavailable. Please try again in a minute." }), {
+      status: 503,
+      headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "https://namehim.app" }
+    });
     } catch (err) {
       console.error("Unhandled worker error:", err);
       return errorResponse("Service unavailable. Please try again in a moment.", 500);
@@ -474,6 +411,57 @@ function sortAndFilterReports(reports, options = {}) {
 
   return filtered;
 }
+
+async function readCachedReports(env) {
+  try {
+    if (!env.CACHE_KV) return null;
+    const cached = await env.CACHE_KV.get(CACHE_KEY, "json");
+    return Array.isArray(cached) ? cached : null;
+  } catch (err) {
+    console.error("KV read error:", err);
+    return null;
+  }
+}
+__name(readCachedReports, "readCachedReports");
+
+async function writeReportsCache(env, reports) {
+  if (!env.CACHE_KV || !Array.isArray(reports)) return;
+  try {
+    await env.CACHE_KV.put(CACHE_KEY, JSON.stringify(reports));
+    await env.CACHE_KV.put(LAST_SUCCESS_KEY, Date.now().toString());
+  } catch (err) {
+    console.error("KV write error:", err);
+  }
+}
+__name(writeReportsCache, "writeReportsCache");
+
+async function getReportsForRead(env, ctx, options = {}) {
+  const bypassCache = Boolean(options.bypassCache);
+  const cached = await readCachedReports(env);
+
+  if (cached && !bypassCache) {
+    if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshIfStale(env));
+    return cached;
+  }
+
+  try {
+    const reports = await fetchAllReportsFromD1(env);
+    if (Array.isArray(reports)) {
+      await writeReportsCache(env, reports);
+      return reports;
+    }
+  } catch (err) {
+    console.error("D1 reports fetch failed:", err);
+  }
+
+  if (cached) {
+    console.warn("Serving stale reports cache after D1 fetch failure.");
+    return cached;
+  }
+
+  return null;
+}
+__name(getReportsForRead, "getReportsForRead");
 
 async function refreshIfStale(env) {
   if (!env.CACHE_KV) return;


### PR DESCRIPTION
### Motivation
- The site was forcing cache-busting requests (`refresh=1` / `t=`) from the frontend which caused the Worker to hit D1 on every load and surface 500/503 when D1 was unavailable.  
- Endpoints duplicated KV/D1 read logic and returned errors instead of serving a working cached response.  
- Make the API resilient so the site can show existing cached reports when D1 is temporarily failing.

### Description
- Remove cache-busting query params from the frontend report/stat requests in `index.html` so clients request the cached endpoints instead of forcing fresh D1 reads (`/reports`, `/filtered-reports`, `/stats`).
- Add shared read-through cache helpers in `worker/index.js`: `readCachedReports`, `writeReportsCache`, and `getReportsForRead` to centralize KV + D1 behavior.  
- Update `/reports`, `/stats`, and `/filtered-reports` handlers in the Worker to use `getReportsForRead(env, ctx, { bypassCache })` so a stale KV cache will be served when D1 fetch fails, and KV is refreshed asynchronously when possible.  
- Keep existing fallback logic for pagination (client still falls back to full fetch), and keep `refreshIfStale` background refresh behavior.

### Testing
- Static check with `node --check worker/index.js` succeeded.  
- Mocked worker smoke tests: ran the Worker module in Node with a mocked `CACHE_KV` and simulated D1 outage to verify `/reports`, `/stats`, and `/filtered-reports` return cached data (200) when KV is present and return `503` when there is no cache; the test output: `worker stale-cache fallback checks passed`.  
- Ran `git diff --check` and commit created (`Fix report API stale cache fallback`).  
- Attempted live `curl` checks against `https://api.namehim.app/*` but they were blocked by the environment proxy (`CONNECT tunnel failed, response 403`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200de39a04832f8affe8af7b49d18e)