### PR TITLE
Update site status messaging and add About-page update paragraph

### DIFF
--- a/about.html
+++ b/about.html
@@ -419,7 +419,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working very hard to update and maintain this site so it remains functional and useful. Please click Donate Now to support the site in this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>
@@ -468,6 +468,7 @@
 
         <section id="recent-setback">
           <h3>Recent Setback and Request for Support</h3>
+          <p><strong>Update:</strong> The ability to submit reports and community posts has been restored, and we have also recovered all of the community posts. We are still experiencing issues that we are working hard to fix to make sure the site is fully functional as intended. If you experience any issues yourself, or if you have any other suggestions or comments, please reach out to the site email, <a href="mailto:namehim.app@proton.me">namehim.app@proton.me</a>. For anyone who has sent an email recently and has not gotten a reply yet, please be patient; this is a volunteer project, and the people working on and maintaining this site all have other responsibilities as well. Thank you to everyone who has supported the site, and thank you to everyone who has been patient with the admin and moderators of the site. We are committed to keeping this site functional and useful.</p>
           <p>Unfortunately, the site's database provider deleted the site's data and account without warning. Fortunately, I prioritized keeping a backup list of the reports, and as you can see, the reports are still available on the site. However, as the administrator and developer of this project, I failed to treat the backup of the community stories with the same urgency. I take responsibility for that mistake, and I sincerely ask forgiveness from anyone who took the time to share a story, offer advice to others, or post messages of hope and empowerment.</p>
           <p>The community page felt like the heart of the site, and it is painful that so much anonymous expression from people who have experienced abuse may now be lost. If you have screenshots, saved text, cached pages, or any other record of the community stories page or its content, please reach out to the site email, <a href="mailto:namehim.app@proton.me">namehim.app@proton.me</a>, and let me know. Even if you only have a screenshot of a few stories, we may be able to add those back.</p>
           <p>I will work to restore the report submission and story submission features, but until then, they are unfortunately down while I find a new data service for the site.</p>

--- a/index.html
+++ b/index.html
@@ -736,7 +736,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working very hard to update and maintain this site so it remains functional and useful. Please click Donate Now to support the site in this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="about.html#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>

--- a/resources.html
+++ b/resources.html
@@ -249,7 +249,7 @@
   <div class="site-alert-wrap">
     <div class="container">
       <div class="site-alert" role="status" aria-live="polite">
-        <p>We are working to restore full functionality to the site, and restore the user-submitted community page stories. Please click Donate Now to support the site and this effort, or click Learn More for a more detailed explanation.</p>
+        <p>We are working very hard to update and maintain this site so it remains functional and useful. Please click Donate Now to support the site in this effort, or click Learn More for a more detailed explanation.</p>
         <div class="site-alert-actions">
           <a class="site-alert-button learn-more" href="about.html#recent-setback">Learn More</a>
           <a class="site-alert-button donate-now" href="https://www.paypal.com/ncp/payment/Y88TMRL6PM2EQ" target="_blank" rel="noopener noreferrer">Donate Now</a>


### PR DESCRIPTION
### Motivation
- Replace the existing top alert copy with a clearer two-sentence message to match the requested wording while keeping the existing Learn More and Donate Now buttons. 
- Add a new bolded “Update:” paragraph at the top of the About page’s Recent Setback section to communicate that report and community post functionality was restored and to provide guidance to users.

### Description
- Replaced the site-alert paragraph text in `index.html`, `resources.html`, and `about.html` with the new two-sentence message. 
- Inserted a new paragraph `<p><strong>Update:</strong> ...</p>` before the existing “Unfortunately…” paragraph in `about.html` containing the provided, grammar-corrected update text and the site email link. 
- Preserved existing Learn More / Donate Now buttons and left the rest of the About page content unchanged.

### Testing
- Ran content assertions using a small `python3 - <<'PY' ...` script to verify the updated alert text is present in `index.html`, `resources.html`, and `about.html` and that the new `<strong>Update:</strong>` paragraph exists in `about.html`, and those assertions passed. 
- Started a local server with `python3 -m http.server` and re-validated the page content, which passed. 
- Ran `git diff --check` to ensure there are no whitespace/diff issues and it passed. 
- Attempted an automated screenshot using `npx --yes playwright@latest screenshot --browser=chromium ...` but the attempt failed due to `npm` registry access returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200c1e3914832f87e89db5591be31d)