### PR TITLE
Show approved community post count in header

### DIFF
--- a/index.html
+++ b/index.html
@@ -749,7 +749,7 @@
     <div class="container header-inner">
       <div class="site-title-wrap">
         <h1><a class="site-title-link" href="index.html#/browse">NameHim</a></h1>
-        <p id="report-count" class="report-count">Loading reports and counting...</p>
+        <p id="report-count" class="report-count">Loading number of community posts...</p>
       </div>
       <nav>
         <a href="#/browse" class="nav-link" data-route="#/browse">Browse</a>
@@ -1938,6 +1938,10 @@ async function filterReportsByState(stateFullName) {
     link.classList.toggle('active', link.getAttribute('data-route') === route);
   });
 
+  if (route !== '#/community') {
+    stopCommunityPostCountLoadingAnimation();
+  }
+
   updateBrowseViewFromRoute();
 
   if (route === '#/browse' && !getReportIdFromUrl()) {
@@ -2025,21 +2029,44 @@ function addStoryTimestamp() {
     }
 
     function updateReportCount(total) {
+      if (getCurrentRoute() === '#/community') {
+        return;
+      }
       reportCount.textContent = formatReportTotal(total) + ' reports and counting...';
+    }
+
+    function updateCommunityPostCount(total) {
+      if (getCurrentRoute() !== '#/community') {
+        return;
+      }
+      reportCount.textContent = formatReportTotal(total) + ' community posts shared';
+    }
+
+    function setCommunityPostCountLoadError() {
+      if (getCurrentRoute() !== '#/community') {
+        return;
+      }
+      reportCount.textContent = 'Unable to load community posts.';
     }
 
     const loadingDots = ['.', '..', '...'];
     let loadingDotIndex = 0;
     let reportCountLoadingInterval = null;
+    let communityPostCountLoadingInterval = null;
 
     function startReportCountLoadingAnimation() {
-      if (!reportCount || reportCountLoadingInterval) {
+      if (!reportCount || reportCountLoadingInterval || getCurrentRoute() === '#/community') {
         return;
       }
 
+      stopCommunityPostCountLoadingAnimation();
       reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
       reportCountLoadingInterval = setInterval(() => {
         loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
+        if (getCurrentRoute() === '#/community') {
+          stopReportCountLoadingAnimation();
+          return;
+        }
         reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
       }, 1000);
     }
@@ -2051,6 +2078,33 @@ function addStoryTimestamp() {
 
       clearInterval(reportCountLoadingInterval);
       reportCountLoadingInterval = null;
+      loadingDotIndex = 0;
+    }
+
+    function startCommunityPostCountLoadingAnimation() {
+      if (!reportCount || communityPostCountLoadingInterval || getCurrentRoute() !== '#/community') {
+        return;
+      }
+
+      stopReportCountLoadingAnimation();
+      reportCount.textContent = 'Loading number of community posts' + loadingDots[loadingDotIndex];
+      communityPostCountLoadingInterval = setInterval(() => {
+        loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
+        if (getCurrentRoute() !== '#/community') {
+          stopCommunityPostCountLoadingAnimation();
+          return;
+        }
+        reportCount.textContent = 'Loading number of community posts' + loadingDots[loadingDotIndex];
+      }, 1000);
+    }
+
+    function stopCommunityPostCountLoadingAnimation() {
+      if (!communityPostCountLoadingInterval) {
+        return;
+      }
+
+      clearInterval(communityPostCountLoadingInterval);
+      communityPostCountLoadingInterval = null;
       loadingDotIndex = 0;
     }
 
@@ -2573,6 +2627,7 @@ async function loadMapStats() {
     async function loadApprovedStories(options = {}) {
       const storyId = options.storyId || null;
       storiesContainer.innerHTML = '<p>Loading stories...</p>';
+      startCommunityPostCountLoadingAnimation();
       const params = new URLSearchParams();
       if (storyId) params.set('id', storyId);
       params.set('refresh', '1');
@@ -2584,6 +2639,9 @@ async function loadMapStats() {
         if (!response.ok) throw new Error(`Stories endpoint returned ${response.status}`);
         const data = await response.json();
         const stories = data && Array.isArray(data.stories) ? data.stories : [];
+        const approvedPostTotal = Number.isFinite(Number(data && data.total)) ? Number(data.total) : stories.length;
+        stopCommunityPostCountLoadingAnimation();
+        updateCommunityPostCount(approvedPostTotal);
 
         if (!stories.length) {
           approvedStories = [];
@@ -2606,6 +2664,8 @@ async function loadMapStats() {
         storiesContainer.innerHTML = html;
       } catch (error) {
         console.error('Failed to load stories:', error);
+        stopCommunityPostCountLoadingAnimation();
+        setCommunityPostCountLoadError();
         storiesContainer.innerHTML = '<p>Error loading stories.</p>';
       }
     }

--- a/worker/index.js
+++ b/worker/index.js
@@ -107,8 +107,11 @@ export default {
     if (request.method === "GET" && url.pathname === "/stories") {
       const storyId = url.searchParams.get("id");
       try {
-        const stories = await fetchApprovedStoriesFromD1(env, storyId);
-        return new Response(JSON.stringify({ stories }), {
+        const [stories, total] = await Promise.all([
+          fetchApprovedStoriesFromD1(env, storyId),
+          countApprovedStoriesFromD1(env)
+        ]);
+        return new Response(JSON.stringify({ stories, total }), {
           status: 200,
           headers: { "Content-Type": "application/json", ...corsHeaders() }
         });
@@ -521,6 +524,27 @@ async function getTableColumns(db, tableName) {
 }
 __name(getTableColumns, "getTableColumns");
 
+function getStoryApprovalFilter(storyColumns) {
+  const approvalColumn = storyColumns.has("is_approved") ? "is_approved" : (storyColumns.has("approved") ? "approved" : null);
+  return approvalColumn
+    ? `(${approvalColumn} = 1 OR ${approvalColumn} = true OR lower(CAST(${approvalColumn} AS TEXT)) = 'true')`
+    : "1 = 1";
+}
+__name(getStoryApprovalFilter, "getStoryApprovalFilter");
+
+async function countApprovedStoriesFromD1(env) {
+  const db = getD1Database(env);
+  const storyColumns = await getTableColumns(db, "stories");
+  if (!storyColumns.size) {
+    throw new Error("stories table is missing or has no columns");
+  }
+  const approvalFilter = getStoryApprovalFilter(storyColumns);
+  const { results } = await db.prepare(`SELECT COUNT(*) AS total FROM stories WHERE ${approvalFilter}`).all();
+  const row = results && results[0] ? results[0] : {};
+  return Number(row.total) || 0;
+}
+__name(countApprovedStoriesFromD1, "countApprovedStoriesFromD1");
+
 async function fetchApprovedStoriesFromD1(env, storyId = null) {
   const db = getD1Database(env);
 
@@ -539,10 +563,7 @@ async function fetchApprovedStoriesFromD1(env, storyId = null) {
     storyColumns.has("category") ? "category" : "'General' AS category",
     storyColumns.has("admin_reply") ? "admin_reply" : "'' AS admin_reply"
   ];
-  const approvalColumn = storyColumns.has("is_approved") ? "is_approved" : (storyColumns.has("approved") ? "approved" : null);
-  const approvalFilter = approvalColumn
-    ? `(${approvalColumn} = 1 OR ${approvalColumn} = true OR lower(CAST(${approvalColumn} AS TEXT)) = 'true')`
-    : "1 = 1";
+  const approvalFilter = getStoryApprovalFilter(storyColumns);
   const orderBy = createdAtColumn ? `${createdAtColumn} DESC` : `${idColumn} DESC`;
 
   const baseSelect = `SELECT ${selectColumns.join(", ")} FROM stories WHERE ${approvalFilter}`;


### PR DESCRIPTION
### Motivation
- Surface a community-specific count in the site header so the Community route shows a loading message for community posts and then displays the number of approved community posts (`is_approved` true) once loaded. 
- Ensure the backend returns an approved-post total so the UI can reliably display the number of approved community stories.

### Description
- Updated `index.html` header text to start with `Loading number of community posts...` and added UI helpers `updateCommunityPostCount`, `setCommunityPostCountLoadError`, `startCommunityPostCountLoadingAnimation`, and `stopCommunityPostCountLoadingAnimation` to manage loading state and prevent `updateReportCount` from clobbering the community count. 
- Modified `loadApprovedStories()` in `index.html` to read the returned `total` from the `/stories` API and call `updateCommunityPostCount` so the header switches to `X community posts shared` after load. 
- Added route cleanup so the community loading animation is stopped when navigating away from `#/community`. 
- Extended the worker (`worker/index.js`) to expose a count of approved stories by adding `getStoryApprovalFilter` and `countApprovedStoriesFromD1`, and changed the `/stories` endpoint to return `{ stories, total }` using the approval filter that checks `is_approved` or `approved` truthy values.

### Testing
- Ran syntax checks with `node --check /tmp/index-script.js` and `node --check /tmp/worker-index.mjs`, both of which succeeded. 
- Ran `git diff --check` which produced no issues. 
- Attempted to run Playwright via `npx --yes playwright --version` to capture a UI screenshot but the npm registry returned `403 Forbidden`, so Playwright could not be installed and no browser-based checks were performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200f340608832fa07f3d57e3cef98b)