### PR TITLE
Show approved community post count in header and return total from /stories

### DIFF
--- a/index.html
+++ b/index.html
@@ -2025,22 +2025,45 @@ function addStoryTimestamp() {
     }
 
     function updateReportCount(total) {
+      if (!reportCount || getCurrentRoute() === '#/community') {
+        return;
+      }
       reportCount.textContent = formatReportTotal(total) + ' reports and counting...';
+    }
+
+    let approvedCommunityPostCount = null;
+
+    function updateCommunityPostCount(total) {
+      approvedCommunityPostCount = Number(total) || 0;
+      if (!reportCount || getCurrentRoute() !== '#/community') {
+        return;
+      }
+      reportCount.textContent = formatReportTotal(approvedCommunityPostCount) + ' community posts shared';
     }
 
     const loadingDots = ['.', '..', '...'];
     let loadingDotIndex = 0;
     let reportCountLoadingInterval = null;
+    let reportCountLoadingMessage = 'Loading reports and counting';
 
-    function startReportCountLoadingAnimation() {
-      if (!reportCount || reportCountLoadingInterval) {
+    function startReportCountLoadingAnimation(message = 'Loading reports and counting') {
+      if (!reportCount) {
         return;
       }
 
-      reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+      if (reportCountLoadingInterval && reportCountLoadingMessage !== message) {
+        stopReportCountLoadingAnimation();
+      }
+
+      if (reportCountLoadingInterval) {
+        return;
+      }
+
+      reportCountLoadingMessage = message;
+      reportCount.textContent = reportCountLoadingMessage + loadingDots[loadingDotIndex];
       reportCountLoadingInterval = setInterval(() => {
         loadingDotIndex = (loadingDotIndex + 1) % loadingDots.length;
-        reportCount.textContent = 'Loading reports and counting' + loadingDots[loadingDotIndex];
+        reportCount.textContent = reportCountLoadingMessage + loadingDots[loadingDotIndex];
       }, 1000);
     }
 
@@ -2573,6 +2596,7 @@ async function loadMapStats() {
     async function loadApprovedStories(options = {}) {
       const storyId = options.storyId || null;
       storiesContainer.innerHTML = '<p>Loading stories...</p>';
+      startReportCountLoadingAnimation('Loading number of community posts');
       const params = new URLSearchParams();
       if (storyId) params.set('id', storyId);
       const queryString = params.toString();
@@ -2583,6 +2607,8 @@ async function loadMapStats() {
         if (!response.ok) throw new Error(`Stories endpoint returned ${response.status}`);
         const data = await response.json();
         const stories = data && Array.isArray(data.stories) ? data.stories : [];
+        const approvedPostTotal = Number.isFinite(Number(data && data.total)) ? Number(data.total) : stories.length;
+        updateCommunityPostCount(approvedPostTotal);
 
         if (!stories.length) {
           approvedStories = [];
@@ -2606,6 +2632,8 @@ async function loadMapStats() {
       } catch (error) {
         console.error('Failed to load stories:', error);
         storiesContainer.innerHTML = '<p>Error loading stories.</p>';
+      } finally {
+        stopReportCountLoadingAnimation();
       }
     }
 

--- a/worker/index.js
+++ b/worker/index.js
@@ -115,7 +115,10 @@ export default {
         return errorResponse("Unable to load stories", 503);
       }
 
-      return new Response(JSON.stringify({ stories: filterStoriesById(stories, storyId) }), {
+      return new Response(JSON.stringify({
+        stories: filterStoriesById(stories, storyId),
+        total: stories.length
+      }), {
         status: 200,
         headers: { "Content-Type": "application/json", ...corsHeaders() }
       });


### PR DESCRIPTION
### Motivation
- Make the site header reflect the community page state by showing a loading message specific to community posts and then display the number of approved community posts once loaded.
- Prevent the global report total from overwriting the header when the user is on the Community page.
- Ensure single-story/community views can still know the overall approved post count by exposing the total from the stories API.

### Description
- Added `approvedCommunityPostCount` state and `updateCommunityPostCount(total)` to update the header to `N community posts shared` when on the `#/community` route in `index.html`.
- Changed `startReportCountLoadingAnimation` to accept a configurable message and reused it to show `Loading number of community posts` while community posts are being fetched in `loadApprovedStories`.
- Modified `loadApprovedStories` to read `data.total` from the `/stories` response, call `updateCommunityPostCount`, and ensure the loading animation is stopped in a `finally` block.
- Updated the worker endpoint for `GET /stories` in `worker/index.js` to include `total: stories.length` in the JSON response (stories are already filtered to approved entries).

### Testing
- Ran `node --check worker/index.js` and the syntax check succeeded.
- Extracted and checked the inline scripts with `node --check /tmp/namehim-index.js` and the syntax check succeeded.
- Ran `git diff --check` to verify no whitespace/syntax diffs issues and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2017f5671c832fb87be0ac55a8caa2)