### PR TITLE
Fix shared report route loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1890,7 +1890,7 @@ async function filterReportsByState(stateFullName) {
       setBrowseTitleForSingleReport(null);
     }
 
-    function updateBrowseViewFromRoute(options = {}) {
+    async function updateBrowseViewFromRoute(options = {}) {
       const preserveBrowsePage = Boolean(options.preserveBrowsePage);
       const route = getCurrentRoute();
       if (route !== '#/browse') {
@@ -1905,15 +1905,31 @@ async function filterReportsByState(stateFullName) {
         activeSingleReportId = null;
         setSingleReportControlsVisible(false);
         setBrowseTitleForSingleReport(null);
-        applySearchFilter({ preservePage: preserveBrowsePage });
+        await applySearchFilter({ preservePage: preserveBrowsePage });
         return;
       }
 
-      if (!hasLoadedReports) {
+      activeSingleReportId = reportId;
+      setSingleReportControlsVisible(true);
+      browseMessage.textContent = 'Loading shared report...';
+      browseMessage.className = 'message';
+
+      const loaded = await ensureFullListLoaded();
+      if (!loaded) {
         return;
       }
 
-      const matched = allReports.find((report) => String(report.id) === reportId);
+      if (getCurrentRoute() !== '#/browse' || getReportIdFromUrl() !== reportId) {
+        return;
+      }
+
+      allReports = fullReportsList;
+      window.allReports = allReports;
+      allTotalCount = fullReportsList.length;
+      hasLoadedReports = true;
+      updateReportCount(allTotalCount);
+
+      const matched = fullReportsList.find((report) => String(report.id) === reportId);
       if (matched) {
         showSingleReport(matched);
       } else {


### PR DESCRIPTION
### Motivation

- Direct shared links to a single report (`#/browse?report=ID`) could land on a page that never showed the individual report because the paginated page load path returned early before any reports were available. 
- The UX showed a persistent "Loading reports and counting..." state or rendered stale content after navigation when opening a shared URL. 

### Description

- Convert `updateBrowseViewFromRoute` to an `async` function and load the full report list when a `report` query parameter is present so the shared report can be located via `fullReportsList` in `index.html`. 
- Show a transient shared-report loading message (`Loading shared report...`) and make the view guard against route/staleness changes during the async load. 
- Populate `allReports`, `allTotalCount`, and `hasLoadedReports` from the full list and call `updateReportCount` before rendering the single report or the not-found state. 

### Testing

- Ran `node --check /tmp/namehim-main.js` and it succeeded. 
- Ran `git diff --check` and it reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2299466f0c832fa2b1f3980f676086)