### PR TITLE
Fix community story timestamps

### DIFF
--- a/index.html
+++ b/index.html
@@ -2093,23 +2093,46 @@ function addStoryTimestamp() {
       loadingDotIndex = 0;
     }
 
-    function formatTimestamp(timestamp) {
-      if (!timestamp) {
-        return '';
+    function normalizeTimestampForDisplay(timestamp) {
+      if (timestamp === null || timestamp === undefined || timestamp === '') {
+        return null;
+      }
+
+      if (typeof timestamp === 'number' && Number.isFinite(timestamp)) {
+        return new Date(timestamp < 100000000000 ? timestamp * 1000 : timestamp);
       }
 
       const timestampValue = String(timestamp).trim();
       if (!timestampValue) {
-        return '';
+        return null;
       }
 
-      const hasTimezoneInfo = /([zZ]|[+-]\d{2}:?\d{2})$/.test(timestampValue);
-      const normalizedTimestamp = hasTimezoneInfo
-        ? timestampValue
-        : timestampValue.replace(' ', 'T') + 'Z';
+      if (/^\d+$/.test(timestampValue)) {
+        const numericTimestamp = Number(timestampValue);
+        if (Number.isFinite(numericTimestamp)) {
+          return new Date(numericTimestamp < 100000000000 ? numericTimestamp * 1000 : numericTimestamp);
+        }
+      }
 
-      const date = new Date(normalizedTimestamp);
-      if (Number.isNaN(date.getTime())) {
+      let normalizedTimestamp = timestampValue
+        .replace(/^(\d{4}-\d{2}-\d{2})\s+(\d{2}:\d{2}:\d{2})/, '$1T$2')
+        .replace(/\s+(UTC|GMT)$/i, 'Z')
+        .replace(/(\.\d{3})\d+/, '$1');
+
+      normalizedTimestamp = normalizedTimestamp.replace(/([+-]\d{2})(\d{2})$/, '$1:$2');
+      normalizedTimestamp = normalizedTimestamp.replace(/([+-]\d{2})$/, '$1:00');
+
+      const hasTimezoneInfo = /([zZ]|[+-]\d{2}:\d{2})$/.test(normalizedTimestamp);
+      if (!hasTimezoneInfo) {
+        normalizedTimestamp += 'Z';
+      }
+
+      return new Date(normalizedTimestamp);
+    }
+
+    function formatTimestamp(timestamp) {
+      const date = normalizeTimestampForDisplay(timestamp);
+      if (!date || Number.isNaN(date.getTime())) {
         return '';
       }
 
@@ -2128,12 +2151,10 @@ function addStoryTimestamp() {
     function formatCommunityPostTimestamp(timestamp) {
       const formattedTimestamp = formatTimestamp(timestamp);
       if (!formattedTimestamp) {
-        return 'Unknown date/time (PDT)';
+        return 'Unknown date/time';
       }
 
-      return formattedTimestamp.includes('PDT')
-        ? formattedTimestamp
-        : `${formattedTimestamp} PDT`;
+      return formattedTimestamp;
     }
 
     function hasInvalidLettersOnlyChars(value) {

--- a/worker/index.js
+++ b/worker/index.js
@@ -527,13 +527,29 @@ async function writeStoriesCache(env, stories) {
 }
 __name(writeStoriesCache, "writeStoriesCache");
 
+function normalizeCachedStories(stories) {
+  if (!Array.isArray(stories)) return null;
+  return stories.map((story) => ({
+    ...story,
+    created_at: story?.created_at || story?.createdAt || ""
+  }));
+}
+__name(normalizeCachedStories, "normalizeCachedStories");
+
+function storiesCacheHasCreatedTimestamps(stories) {
+  if (!Array.isArray(stories)) return false;
+  return stories.length === 0 || stories.every((story) => Boolean(story?.created_at || story?.createdAt));
+}
+__name(storiesCacheHasCreatedTimestamps, "storiesCacheHasCreatedTimestamps");
+
 async function getStoriesForRead(env, ctx, options = {}) {
   const bypassCache = Boolean(options.bypassCache);
   const cached = await readCachedStories(env);
+  const normalizedCached = normalizeCachedStories(cached);
 
-  if (cached && !bypassCache) {
+  if (cached && !bypassCache && storiesCacheHasCreatedTimestamps(cached)) {
     if (ctx && typeof ctx.waitUntil === "function") ctx.waitUntil(refreshStoriesIfStale(env));
-    return cached;
+    return normalizedCached;
   }
 
   try {
@@ -546,9 +562,9 @@ async function getStoriesForRead(env, ctx, options = {}) {
     console.error("D1 stories fetch failed:", err);
   }
 
-  if (cached) {
+  if (normalizedCached) {
     console.warn("Serving stale stories cache after D1 fetch failure.");
-    return cached;
+    return normalizedCached;
   }
 
   return null;


### PR DESCRIPTION
### Motivation
- Imported community stories stored in D1/Postgres had `created_at` values in formats (fractional seconds, space-separated datetime, `+00`/`+0000` offsets or Unix seconds) that the frontend failed to parse, causing posts to show “Unknown date/time”.
- Stale cached story entries lacking `created_at` could block fresh D1 data from being shown, so cached fields needed normalization and validation.

### Description
- Added `normalizeTimestampForDisplay` in `index.html` to robustly parse Postgres/D1-style timestamps, space-separated datetimes, fractional seconds, timezone offsets, and Unix seconds/milliseconds before formatting.  
- Updated `formatTimestamp` and `formatCommunityPostTimestamp` to use the new normalizer and to stop forcibly appending a `PDT` suffix, instead returning the browser-formatted Pacific timezone label and using the shorter fallback string `Unknown date/time`.  
- In `worker/index.js` added `normalizeCachedStories` and `storiesCacheHasCreatedTimestamps` to normalize cached `createdAt`/`created_at` fields and ensure cached entries without created timestamps do not prevent fresh D1 fetches.  
- Adjusted `getStoriesForRead` to return normalized cached stories only when cached entries include created timestamps and to fall back to normalized cached data on D1 fetch failures.

### Testing
- Ran `node --check worker/index.js` with no syntax errors.  
- Executed a Node snippet that loads the new frontend timestamp functions and validated a set of representative inputs (`2025-06-08 14:30:45.123456+00`, `2025-06-08 14:30:45+0000`, `2025-06-08 14:30:45+00`, `2025-06-08 14:30:45`, `1749393045`, `1749393045000`), and each case formatted to a Pacific time string instead of `Unknown date/time`.  
- All automated checks and the timestamp-formatting validations succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2672900b58832f9333d90da42c5b40)